### PR TITLE
Remove forks from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,17 @@
 > Guide
 - https://github.com/QianMo/Game-Programmer-Study-Notes
 - https://github.com/ThisisGame/cpp-game-engine-book
-- https://github.com/gmh5225/GameEngine-GameEngineFromScratch
+- https://github.com/netwarm007/GameEngineFromScratch
 - https://forums.unrealengine.com [Unreal]
 - https://docs.unrealengine.com [Unreal]
 - https://www.unrealengine.com/resources [Unreal]
-- https://github.com/gmh5225/ue4-tutorials [Unreal]
-- https://github.com/gmh5225/Unreal-Development-Guides-and-Tips [Unreal]
+- https://github.com/tomlooman/ue4-tutorials [Unreal]
+- https://github.com/JaredP94/Unreal-Development-Guides-and-Tips [Unreal]
 - https://github.com/lettier/3d-game-shaders-for-beginners [Shader]
 - https://github.com/PardCode/OpenGL-3D-Game-Tutorial-Series [OpenGL]
 - https://github.com/PardCode/CPP-3D-Game-Tutorial-Series [DirectX]
 - https://github.com/ssloy/tinyrenderer [Render]
-- https://github.com/gmh5225/Unity-GameDev [Unity]
+- https://github.com/crazyshader/GameDev [Unity]
 - https://github.com/QianMo/Unity-Design-Pattern [Unity Design]
 
 > Source
@@ -26,10 +26,10 @@
 - https://github.com/CRYTEK/CRYENGINE
 - https://github.com/panda3d/panda3d
 - https://github.com/ValveSoftware/source-sdk-2013
-- https://github.com/gmh5225/GameEngine-source-engine.2003
-- https://github.com/gmh5225/GameEngine-SourceEngine2007
+- https://github.com/UTINKA/source-engine.2003
+- https://github.com/VSES/SourceEngine2007
 - https://github.com/nillerusr/source-engine
-- https://github.com/gmh5225/GoldSourceRebuild [GoldSource engine rebuild]
+- https://github.com/Triang3l/GoldSourceRebuild [GoldSource engine rebuild]
 - https://github.com/adriengivry/Overload
 - https://github.com/flwmxd/MapleEngine
 - https://github.com/inanevin/LinaEngine
@@ -61,30 +61,30 @@
 - https://github.com/TrinityCore/TrinityCore [MMORPG]
 - https://github.com/solenum/exengine [C99 3D]
 - https://github.com/TheCherno/Hazel
-- https://github.com/gmh5225/GameEngine-yourgamelib
-- https://github.com/gmh5225/GameEngine-Base
-- https://github.com/gmh5225/GameEngine-Castle-Engine [DX11]
-- https://github.com/gmh5225/GameEngine-ioquake3-engine [quake3]
-- https://github.com/gmh5225/GameEngine-rbfx [C# support and WYSIWYG editor]
-- https://github.com/gmh5225/GameEngine-Esoterica
-- https://github.com/gmh5225/gameengine-gzdoom [Doom]
+- https://github.com/duddel/yourgamelib
+- https://github.com/Serious-Engine/Base
+- https://github.com/benanil/Castle-Engine [DX11]
+- https://github.com/OpenArena/engine [quake3]
+- https://github.com/rbfx/rbfx [C# support and WYSIWYG editor]
+- https://github.com/BobbyAnguelov/Esoterica
+- https://github.com/ZDoom/gzdoom [Doom]
 
 
 > Game Engine Plugins:Unreal
-- [Plugin for UE4 to user Rider for Unreal Engine as code editor](https://github.com/gmh5225/UE4-plugin-RiderSourceCodeAccess)
+- [Plugin for UE4 to user Rider for Unreal Engine as code editor](https://github.com/JetBrains/RiderSourceCodeAccess)
 - [Design-agnostic node system for scripting game’s flow in Unreal Engine](https://github.com/MothCocoon/FlowGraph)
-- [Sample Unreal Engine 5.0.1 C++ Project That Incorporates Dear ImGui](https://github.com/gmh5225/UE5-With-Dear-ImGui)
-- [A set of tools and utilities for use with Unreal Engine projects using ImGui](https://github.com/gmh5225/UE-IMGUI-UnrealImGuiTools)
-- [A simple Unreal Engine subsystem to provide a more accurate server world time to clients](https://github.com/gmh5225/UE-Plugin-NetworkTimeSync)
-- [UE4 UI Texture Validator Plugin](https://github.com/gmh5225/UE-BUIValidator)
+- [Sample Unreal Engine 5.0.1 C++ Project That Incorporates Dear ImGui](https://github.com/stungeye/UE5-With-Dear-ImGui)
+- [A set of tools and utilities for use with Unreal Engine projects using ImGui](https://github.com/nakdeyes/UnrealImGuiTools)
+- [A simple Unreal Engine subsystem to provide a more accurate server world time to clients](https://github.com/Erlite/NetworkTimeSync)
+- [UE4 UI Texture Validator Plugin](https://github.com/benui-dev/UE-BUIValidator)
 - [Unreal Engine .NET 6 integration](https://github.com/nxrighthere/UnrealCLR)
-- [Houdini Engine Plugin for Unreal Engine](https://github.com/gmh5225/HoudiniEngineForUnreal)
-- [A small tutorial repository on capturing images with semantic annotation from UnrealEngine to disk](https://github.com/gmh5225/UE-UnrealImageCapture)
-- [UE4 plugin for live2d model](https://github.com/gmh5225/UE-Plugin-UnrealLive2D)
+- [Houdini Engine Plugin for Unreal Engine](https://github.com/sideeffects/HoudiniEngineForUnreal)
+- [A small tutorial repository on capturing images with semantic annotation from UnrealEngine to disk](https://github.com/TimmHess/UnrealImageCapture)
+- [UE4 plugin for live2d model](https://github.com/Arisego/UnrealLive2D)
 
 > Game Engine Plugins:Unity
-- [A markdown viewer for unity](https://github.com/gmh5225/Unity-MarkdownViewer)
-- [An integrated solution for authoring / importing / simulating / rendering strand-based hair in Unity](https://github.com/gmh5225/unity-com.unity.demoteam.hair)
+- [A markdown viewer for unity](https://github.com/gwaredd/UnityMarkdownViewer)
+- [An integrated solution for authoring / importing / simulating / rendering strand-based hair in Unity](https://github.com/Unity-Technologies/com.unity.demoteam.hair)
 
 
 > Game Engine Detector
@@ -94,16 +94,16 @@
 ## Mathematics
 - https://github.com/Groovounet/glm
 - https://github.com/Kazade/kazmath
-- https://github.com/gmh5225/math-int_fastdiv
-- https://github.com/gmh5225/Math-fdlibm
+- https://github.com/milakov/int_fastdiv
+- https://github.com/freemint/fdlibm
 
 ## Renderer
-- https://github.com/gmh5225/Renderer-SoftGLRender
-- https://github.com/gmh5225/Render-VolumetricReSTIRRelease
-- https://github.com/gmh5225/Render-NonEuclidean
-- [A graphics engine designed to run on a single thread on CPU](https://github.com/gmh5225/graphics-CPUEngine) 
-- https://github.com/gmh5225/learn-OpenGL-render-gltut [OpenGL Render]
-- https://github.com/gmh5225/raytracing [RayTracer]
+- https://github.com/keith2018/SoftGLRender
+- https://github.com/DQLin/VolumetricReSTIRRelease
+- https://github.com/HackerPoet/NonEuclidean
+- [A graphics engine designed to run on a single thread on CPU](https://github.com/FHowington/CPUEngine) 
+- https://github.com/paroj/gltut [OpenGL Render]
+- https://github.com/ashawkey/raytracing [RayTracer]
 
 ## 3D Graphics
 - https://github.com/Mesa3D/mesa
@@ -120,27 +120,27 @@
 - https://github.com/Twinklebear/tobj [Rust]
 
 ## Task Scheduler
-- https://github.com/gmh5225/scheduler-TaskScheduler
+- https://github.com/SergeyMakeev/TaskScheduler
 
 ## Game Network
 > Guide
 - https://github.com/MFatihMAR/Game-Networking-Resources
 - https://partner.steamgames.com/doc/api/ISteamNetworkingMessages#functions_sendrecv [Steam]
-- https://github.com/gmh5225/mqtt [mqtt]
+- https://github.com/mcxiaoke/mqtt [mqtt]
 
 > Source
-- https://github.com/gmh5225/skynet
-- https://github.com/gmh5225/Game-server-engine-NoahGameFrame [Server Engine]
+- https://github.com/cloudwu/skynet
+- https://github.com/ketoo/NoahGameFrame [Server Engine]
 - https://github.com/chronoxor/CppServer
 - https://github.com/Qihoo360/evpp
 - https://github.com/ValveSoftware/GameNetworkingSockets [Steam]
 - https://github.com/skywind3000/kcp [KCP]
-- https://github.com/gmh5225/kcp-cpp [KCP]
+- https://github.com/Unit-X/kcp-cpp [KCP]
 - https://github.com/TLeonardUK/ds3os [Dark Souls 3]
 - https://github.com/rathena/rathena [MMORPG]
-- https://github.com/gmh5225/uWebSockets [WebSockets]
+- https://github.com/uNetworking/uWebSockets [WebSockets]
 - https://github.com/socketio/socket.io [Nodejs]
-- https://github.com/gmh5225/MQTT.js [mqtt nodejs]
+- https://github.com/mqttjs/MQTT.js [mqtt nodejs]
 - https://github.com/eclipse/paho.mqtt.cpp [mqtt cpp]
 
 ## NVIDIA PhysX SDK
@@ -152,98 +152,98 @@
 > Guide
 - https://github.com/Calinou/awesome-gamedev
 - https://github.com/notpresident35/learn-awesome-gamedev
-- https://github.com/gmh5225/Unity-GameDev [Unity]
+- https://github.com/crazyshader/GameDev [Unity]
 - https://github.com/QianMo/Unity-Design-Pattern [Unity Design]
 
 > Source
 - https://github.com/PiMoNFeeD/csgo-src [Leaked CSGO]
-- https://github.com/SmileyAG/cstrike15_src-CI [Leaked CSGO With CI]
+- https://github.com/perilouswithadollarsign/cstrike15_src [Leaked CSGO With CI]
 - https://github.com/SwagSoftware/Kisak-Strike [Open Source CSGO]
-- https://github.com/gmh5225/csso-src [CSGO Mod]
+- https://github.com/hampta/csso-src [CSGO Mod]
 - https://github.com/thomaseichhorn/cs16-client [Rewrote CS1.6]
 - https://github.com/td512/re3 [Reversed GTA III, Vice City]
-- https://github.com/gmh5225/Reverse-Game-ReCZDS [Reversed CZeror]
+- https://github.com/SmileyAG/ReCZDS [Reversed CZeror]
 - https://github.com/QianMo/UE4-FPS-Game [UE4 FPS Game]
-- https://github.com/gmh5225/UE4-FirstPersonShooter [UE4 FPS Demo]
-- https://github.com/gmh5225/UE4-SimpleFPSTemplate [UE4 FPS Demo]
-- https://github.com/gmh5225/UE4-EpicSurvivalGame [UE4 FPS Game]
+- https://github.com/KitchenGun/UE4_FPS [UE4 FPS Demo]
+- https://github.com/tomlooman/SimpleFPSTemplate [UE4 FPS Demo]
+- https://github.com/tomlooman/EpicSurvivalGame [UE4 FPS Game]
 - https://github.com/QianMo/UE4-Tank-Game [UE4 Game]
 - https://github.com/gmh5225/UE-UE5-FPS-wlaster [UE5 FPS Game]
 - https://github.com/tomlooman/ActionRoguelike [UE Roguelike Game]
 - https://github.com/Unity-Technologies/FPSSample [Unity Game]
-- https://github.com/gmh5225/Unity-FPS-Movement [Unity FPS]
-- https://github.com/gmh5225/Unity-SQLite-Unity3D [Unity SQLite]
-- https://github.com/gmh5225/Unity-MoBaDemo [Unity MoBa]
+- https://github.com/OguzKaira/FPS-Movement [Unity FPS]
+- https://github.com/OguzKaira/SQLite-Unity3D [Unity SQLite]
+- https://github.com/swordjoinmagic/MoBaDemo [Unity MoBa]
 - https://github.com/ZehMatt/SnakeRoyal [Mini Game With Server]
 - https://github.com/MKXJun/Super-Fighter [DX11 Mini Game]
 - https://github.com/MKXJun/Rubik-Cube [DX9/11 Mini Game]
 - https://github.com/Suprcode/mir2 [MIR2]
-- https://github.com/gmh5225/mir3-zircon [MIR3]
+- https://github.com/Suprcode/mir3-zircon [MIR3]
 - https://github.com/WolfireGames/overgrowth [Overgrowth]
-- https://github.com/gmh5225/Game-hl-mods [Modification For Half-Life]
-- https://github.com/gmh5225/maple-fighters [A small online game similar to MapleStory]
-- https://github.com/gmh5225/Fortnite-1 [Fortnite]
-- https://github.com/gmh5225/doomretro [DOOM]
-- https://github.com/gmh5225/Game-Super-Mario-Bros-game [Remake of Super Mario]
-- https://github.com/gmh5225/Game-2048.cpp [2048]
-- [An open source re-implementation of RollerCoaster Tycoon 2](https://github.com/gmh5225/Game-OpenRCT2)
-- [This is the old Paradise SPRX BO2 soruce code](https://github.com/gmh5225/Game-ParadiseBO2)
-- https://github.com/gmh5225/rehlds [Reverse-engineered HLDS]
-- https://github.com/gmh5225/Android-ModLoader [Android Mod Loader]
-- https://github.com/gmh5225/Game-PythonPlantsVsZombies [PlantsVsZombies]
-- https://github.com/gmh5225/Counter-Strike-DS-Unity-Project [Unity CS]
-- https://github.com/gmh5225/Counter-Strike-Nintendo-DS [Nintendo CS]
-- https://github.com/gmh5225/osu [osu]
-- https://github.com/gmh5225/osu-framework [osu]
-- https://github.com/gmh5225/wow-LegionCore-7.3.5 [wow]
-- https://github.com/gmh5225/wow-5.4.7-Wow-source [wow]
-- https://github.com/gmh5225/wow-MopCore547 [wow]
-- https://github.com/gmh5225/Non-Newtonian-New-York [Spider-Man Remastered Mod]
-- https://github.com/gmh5225/game-cpp-android-basic-samples [Sample games using the Google Play Games C++ SDK]
-- https://github.com/gmh5225/UE-KawaiiPhysics [Simple fake Physics for UnrealEngine4 & 5]
-- https://github.com/gmh5225/UE4-VTuberWithUE4 [UE4 VTuber]
-- https://github.com/gmh5225/Game-YugimonTheSpire [Slay The Spire Remastered Mod]
+- https://github.com/solidi/hl-mods [Modification For Half-Life]
+- https://github.com/codingben/maple-fighters [A small online game similar to MapleStory]
+- https://github.com/loqix/Fortnite [Fortnite]
+- https://github.com/bradharding/doomretro [DOOM]
+- https://github.com/Luxon98/Super-Mario-Bros-game [Remake of Super Mario]
+- https://github.com/plibither8/2048.cpp [2048]
+- [An open source re-implementation of RollerCoaster Tycoon 2](https://github.com/OpenRCT2/OpenRCT2)
+- [This is the old Paradise SPRX BO2 soruce code](https://github.com/gopro2027/ParadiseBO2)
+- https://github.com/dreamstalker/rehlds [Reverse-engineered HLDS]
+- https://github.com/AndroidModLoader/AndroidModLoader [Android Mod Loader]
+- https://github.com/marblexu/PythonPlantsVsZombies [PlantsVsZombies]
+- https://github.com/Fewnity/Counter-Strike-DS-Unity-Project [Unity CS]
+- https://github.com/Fewnity/Counter-Strike-Nintendo-DS [Nintendo CS]
+- https://github.com/ppy/osu [osu]
+- https://github.com/ppy/osu-framework [osu]
+- https://github.com/dufernst/LegionCore-7.3.5 [wow]
+- https://github.com/RageProject/5.4.7-Wow-source [wow]
+- https://github.com/SkyFire/MopCore547 [wow]
+- https://github.com/skMetinek/Non-Newtonian-New-York [Spider-Man Remastered Mod]
+- https://github.com/playgameservices/cpp-android-basic-samples [Sample games using the Google Play Games C++ SDK]
+- https://github.com/pafuhana1213/KawaiiPhysics [Simple fake Physics for UnrealEngine4 & 5]
+- https://github.com/pafuhana1213/VTuberWithUE4 [UE4 VTuber]
+- https://github.com/Bratah123/GojoTheSpire [Slay The Spire Remastered Mod]
 
 ## Game Assets
-- https://github.com/gmh5225/Game-assets-Retro3DGraphicsCollection
-- https://github.com/gmh5225/Game-asset-GOWTool [God of War 2018]
+- https://github.com/Miziziziz/Retro3DGraphicsCollection
+- https://github.com/HitmanHimself/GOWTool [God of War 2018]
 
 ## Game Hot Patch
 - https://github.com/Tencent/xLua
 - https://github.com/Tencent/InjectFix
-- https://github.com/gmh5225/Unity-hotfix-hybridclr
+- https://github.com/focus-creative-games/hybridclr
 
 
 ## Game Testing
 - https://github.com/AirtestProject/Airtest [UI Automation Framework]
 - https://github.com/dendibakh/perf-ninja [Performance Analysis]
-- https://github.com/gmh5225/UptimeFaker [Detecting High PC Uptime]
+- https://github.com/CookiePLMonster/UptimeFaker [Detecting High PC Uptime]
 - https://github.com/GameTechDev/PresentMon [Graphics Performance]
 - https://github.com/gatling/gatling [Server Testing]
-- https://github.com/gmh5225/performance-btop [Performance Monitor]
+- https://github.com/aristocratos/btop [Performance Monitor]
 
 ## Game Tools
-- [Play your favorite games in a borderless window; no more time consuming alt-tabs](https://github.com/gmh5225/Borderless-Gaming)
+- [Play your favorite games in a borderless window; no more time consuming alt-tabs](https://github.com/Codeusa/Borderless-Gaming)
 
 ## DirectX
 > Guide
-- https://github.com/gmh5225/Direct3D-hw3d [C++ 3D DirectX Tutorial]
+- https://github.com/planetchili/hw3d [C++ 3D DirectX Tutorial]
 - https://github.com/jpvanoosten/LearningDirectX12 [DX12]
 - https://github.com/MKXJun/DirectX11-With-Windows-SDK [DX11 zh]
-- https://github.com/gmh5225/D3D-d3d12book [DX12]
+- https://github.com/d3dcoder/d3d12book [DX12]
 
 > Hook
-- https://github.com/gmh5225/D3D11Hook [DX11 Imgui]
-- https://github.com/gmh5225/DX11-BaseHook [DX11 Imgui]
-- https://github.com/gmh5225/D3D12-Hook-ImGui [DX12 Imgui]
-- https://github.com/gmh5225/DirectX11Hook [DX11 Imgui]
+- https://github.com/xo1337/D3D11Hook [DX11 Imgui]
+- https://github.com/rdbo/DX11-BaseHook [DX11 Imgui]
+- https://github.com/DrNseven/D3D12-Hook-ImGui [DX12 Imgui]
+- https://github.com/niemand-sec/DirectX11Hook [DX11 Imgui]
 - https://github.com/guided-hacking/GH_D3D11_Hook [DX11]
-- https://github.com/gmh5225/D3D11-Discord-Overlay-Hook [DX11]
+- https://github.com/gogo9211/Discord-Overlay-Hook [DX11]
 - https://github.com/ocornut/imgui/commit/923bd2fd217c1dc1e75fa92b0284d3817904988b [DX11/12 ResizeBuffers]
-- https://github.com/gmh5225/d3dhook_imgui [d3d opengl hook imgui x86/x64]
+- https://github.com/marlkiller/d3dhook_imgui [d3d opengl hook imgui x86/x64]
 
 > Tools
-- https://github.com/gmh5225/DX-DX11-3d9 [Fixing broken stereoscopic effects in DX11 games]
+- https://github.com/visotw/3d9 [Fixing broken stereoscopic effects in DX11 games]
 
 > Emulation 
 - https://github.com/code-tom-code/Software_D3D9 [DX9]
@@ -253,7 +253,7 @@
 - https://github.com/microsoft/D3D9On12 [The Direct3D9-On-12 mapping layer]
 
 > Overlay
-- https://github.com/gmh5225/Direct3D9-Overlay
+- https://github.com/SeanPesce/Direct3D9-Overlay
 
 ## Cheat
 > Guide
@@ -282,7 +282,7 @@
 - https://www.unknowncheats.me/forum/unity/465283-il2cppruntimedumper.html [IL2CPP]
 - https://github.com/shalzuth/NativeNetSharp [Injecting C# code]
 - https://github.com/januwA/game-reversed-study [CE Guide zh]
-- https://github.com/gmh5225/CSGO-master-guide [CSGO Guide]
+- https://github.com/csgohacks/master-guide [CSGO Guide]
 - [different-ways-hooking](https://www.unknowncheats.me/forum/general-programming-and-reversing/154643-different-ways-hooking.html) [Hook Guide]
 - http://pwnadventure.com [Hackable Game]
 - https://github.com/GameCrashProject/UE4-Hacking-Guideline [Unreal]
@@ -290,14 +290,14 @@
 > Debugging
 - https://github.com/cheat-engine/cheat-engine
 - https://github.com/SinaKarvandi/Hypervisor-From-Scratch [Hypervisor]
-- https://github.com/gmh5225/CheatEngineMonoHelper [CE Mono Helper]
-- https://github.com/gmh5225/frida-ceserver [CE Server For IOS]
+- https://github.com/JasonGoemaat/CheatEngineMonoHelper [CE Mono Helper]
+- https://github.com/DoranekoSystems/frida-ceserver [CE Server For IOS]
 - https://github.com/isabellaflores/ceserver-pcileech [CE Server For Pcileech]
-- https://github.com/gmh5225/debug-veh [CE Plugin For Manualmap VEH Dll]
+- https://github.com/user23333/veh [CE Plugin For Manualmap VEH Dll]
 - https://github.com/x64dbg/x64dbg
 - https://github.com/marakew/syser
 - https://github.com/ajkhoury/ReClassEx
-- https://github.com/gmh5225/ReClass.NET
+- https://github.com/ReClassNET/ReClass.NET
 - https://github.com/x64dbg/DotX64Dbg
 - https://github.com/imugee/xdv
 - https://github.com/eteran/edb-debugger [For Linux]
@@ -305,7 +305,7 @@
 - https://github.com/mrexodia/TitanHide
 - https://github.com/Air14/HyperHide 
 - https://github.com/HyperDbg/HyperDbg
-- https://github.com/gmh5225/vt-debuger
+- https://github.com/3526779568/vt-debuger
 - https://github.com/changeofpace/Force-Page-Protection [Bypass Remap Memory]
 - https://github.com/icsharpcode/ILSpy [For Unity]
 - https://github.com/dnSpy/dnSpy [For Unity]
@@ -313,30 +313,30 @@
 - https://github.com/mandiant/dncil [For Unity]
 - https://github.com/hugsy/CFB [Monitor IRP]
 - https://ioninja.com/downloads.html [Protocol Analyzer]
-- https://github.com/gmh5225/Anti-SteamAntiAntiDebug [Steam]
+- https://github.com/wilszdev/SteamAntiAntiDebug [Steam]
 
 > Packet Sniffer&Filter
-- https://github.com/gmh5225/packet-win-shaper
-- https://github.com/gmh5225/Packet-ndisapi
-- https://github.com/gmh5225/Akebi-PacketSniffer
+- https://github.com/WPO-Foundation/win-shaper
+- https://github.com/wiresock/ndisapi
+- https://github.com/Akebi-Group/Akebi-PacketSniffer
 
 > Packet Capture&Parse
-- https://github.com/gmh5225/network-PcapPlusPlus [Pcap]
+- https://github.com/seladb/PcapPlusPlus [Pcap]
 
 > SpeedHack
-- https://github.com/gmh5225/CE-Speedhack
-- https://github.com/gmh5225/Speed-Hack
+- https://github.com/absoIute/Speedhack
+- https://github.com/Letomaniy/Speed-Hack
 
 > RE Tools
 - https://dogbolt.org
 - https://github.com/stevemk14ebr/RETools
-- https://github.com/gmh5225/CSharp-patch-ACEPatcher [.NET Patcher]
-- https://github.com/gmh5225/emulate-KACE [Emulate Drivers in RING3 with self context mapping or unicorn]
+- https://github.com/BataBo/ACEPatcher [.NET Patcher]
+- https://github.com/waryas/KACE [Emulate Drivers in RING3 with self context mapping or unicorn]
 - https://github.com/VollRagm/PTView [Browse Page Tables on Windows]
 
 > Fix VMP
-- https://github.com/gmh5225/VMP-NoVmpy
-- https://github.com/gmh5225/VMP-Vmp3_64bit_disasm-prerelease-
+- https://github.com/wallds/NoVmpy
+- https://github.com/Anal-Repair/Vmp3_64bit_disasm-prerelease-
 
 > Fix OLLVM
 - https://bbs.pediy.com/thread-272414.htm
@@ -344,26 +344,26 @@
 > Dynamic Binary Instrumentation
 - https://github.com/hzqst/unicorn_pe
 - https://github.com/googleprojectzero/TinyInst
-- https://github.com/gmh5225/veh-cpp-veh-dbi
-- https://github.com/gmh5225/binary-translator-river
-- https://github.com/gmh5225/DBI-mambo [ARM]
+- https://github.com/revsic/cpp-veh-dbi
+- https://github.com/bitdefender/river
+- https://github.com/beehive-lab/mambo [ARM]
 - https://github.com/DynamoRIO/drmemory
-- https://github.com/gmh5225/Dynamic-Recompliers-dynre-x86
+- https://github.com/aroxby/dynre-x86
 
 > Launcher Abuser
-- https://github.com/gmh5225/launcher-abuser
+- https://github.com/Ricardonacif/launcher-abuser
 
 > Bypass PatchGuard
-- https://github.com/gmh5225/PG-EasyAntiPatchGuard
-- https://github.com/gmh5225/UPGDSED [File]
+- https://github.com/armasm/EasyAntiPatchGuard
+- https://github.com/hfiref0x/UPGDSED [File]
 - https://github.com/Mattiwatti/EfiGuard [EFI]
-- https://github.com/gmh5225/PG1903 [Demo NX]
+- https://github.com/zzhouhe/PG1903 [Demo NX]
 - https://gist.github.com/gmh5225/0a0c8e3a2d718e2d6f9b6a07d5e0f80a [PG CTX]
 - https://github.com/gmh5225/QuickPGTrigger [Stress Testing]
 
 > Windows Kernel Explorer
 - https://github.com/NullArray/WinKernel-Resources [Guide]
-- https://github.com/gmh5225/learn-Document-windrv-linux/tree/master/Windows%20Driver%20Development [Guide]
+- https://github.com/supermanc88/Document/tree/master/Windows%20Driver%20Development [Guide]
 - https://github.com/gmh5225/ntoskrnl_file_collection [Various versions of ntoskrnl files]
 - https://github.com/gmh5225/win32k_file_collection [Various versions of win32k files]
 - https://github.com/gmh5225/win32k_file_collection2 [Various versions of win32k files]
@@ -374,48 +374,48 @@
 - https://github.com/everdox/InfinityHook [ETW Hook]
 - https://github.com/FiYHer/InfinityHookPro [ETW Hook Ex]
 - https://github.com/KelvinMsft/ThreadSpy [PMI Callback]
-- https://github.com/gmh5225/Driver-PerfMon [PMI Callback]
-- https://github.com/gmh5225/Driver-WindowsIntelPT [Intel PT]
-- https://github.com/gmh5225/Driver-intel-pt-ingsoc [Intel PT]
-- https://github.com/gmh5225/Driver-pt-detector [Intel PT]
-- https://github.com/intelpt/winafl-intelpt [Intel PT Fuzzer]
-- https://github.com/gmh5225/Driver-winipt [ipt.sys]
-- https://github.com/gmh5225/pt-decode-processor-trace [Intel PT Decoder]
-- https://github.com/gmh5225/Driver-intel-PEBs-LoopHPCs [Intel PEBs]
-- https://github.com/gmh5225/Driver-Ark [Tool]
+- https://github.com/KelvinMsft/PerfMon [PMI Callback]
+- https://github.com/intelpt/WindowsIntelPT [Intel PT]
+- https://github.com/CristiNacu/ingsoc [Intel PT]
+- https://github.com/DProvinciani/pt-detector [Intel PT]
+- https://github.com/googleprojectzero/winafl [Intel PT Fuzzer]
+- https://github.com/intelpt/winipt [ipt.sys]
+- https://github.com/intelpt/processor-trace [Intel PT Decoder]
+- https://github.com/spomile/LoopHPCs [Intel PEBs]
+- https://github.com/ilovecsad/Ark [Tool]
 - https://github.com/gmh5225/ntoskrnl_file_collection [Ntoskrnl Version]
 - https://github.com/gmh5225/win32k_file_collection [Win32k Version]
 - https://github.com/gmh5225/win32k_file_collection2 [Win32k Version]
 - https://github.com/gmh5225/MSSymbolsCollection [Kernel Symbols]
-- https://github.com/gmh5225/vad-wkpe [Enumerate VAD]
-- https://github.com/gmh5225/Tool-Driver-DriverDllFInder [Find Driver Useless Memory]
-- https://github.com/gmh5225/Driver-APICallProxy [Windows API Call Obfuscation]
-- https://github.com/gmh5225/Driver-MmcopyMemory-Hook [Hook MmcopyMemory]
+- https://github.com/am0nsec/wkpe [Enumerate VAD]
+- https://github.com/armvirus/DriverDllFInder [Find Driver Useless Memory]
+- https://github.com/MahmoudZohdy/APICallProxy [Windows API Call Obfuscation]
+- https://github.com/Spuckwaffel/Simple-MmcopyMemory-Hook [Hook MmcopyMemory]
 - https://github.com/VollRagm/PTView [Browse Page Tables on Windows]
 
 > Magisk
-- https://github.com/gmh5225/Android-Zygisk-MagiskHide
-- https://github.com/gmh5225/android-hideroot
-- https://github.com/gmh5225/Magisk-Riru-MomoHider
+- https://github.com/PShocker/Zygisk-MagiskHide
+- https://github.com/longpoxin/hideroot
+- https://github.com/canyie/Riru-MomoHider
 
 > Android File Explorer
-- https://github.com/gmh5225/android-dex2jar
+- https://github.com/pxb1988/dex2jar
 
 > Android Memory Explorer
-- https://github.com/gmh5225/procmap
-- https://github.com/gmh5225/Android-MemDumper [Dump]
-- https://github.com/gmh5225/Android-Mem-Edit
-- https://github.com/gmh5225/Android-writemem
-- https://github.com/gmh5225/Android-Kernel-rwProcMem33 [Linux read & write process memory module]
+- https://github.com/joaomlneto/procmap
+- https://github.com/kp7742/MemDumper [Dump]
+- https://github.com/mrcang09/Android-Mem-Edit
+- https://github.com/ExploitTheLoop/writemem
+- https://github.com/abcz316/rwProcMem33 [Linux read & write process memory module]
 
 > Android Kernel Explorer
-- https://github.com/gmh5225/Android-Analysis-Cheat-Use-Kernel-op7t [DIY Kernel]
-- https://github.com/gmh5225/android-simpleperf_demo [Perf]
-- https://github.com/gmh5225/android_ebpf [EBPF]
+- https://github.com/yhnu/op7t [DIY Kernel]
+- https://github.com/yabinc/simpleperf_demo [Perf]
+- https://github.com/feicong/android_ebpf [EBPF]
 
 > Virtual Environments
-- https://github.com/gmh5225/Android-BlackBox [Android]
-- https://github.com/gmh5225/flare-vm
+- https://github.com/FBlackBox/BlackBox [Android]
+- https://github.com/mandiant/flare-vm
 - https://github.com/hzqst/VmwareHardenedLoader
 
 > Decompiler
@@ -426,75 +426,75 @@
 - https://github.com/Col-E/Recaf [Java]
 - https://github.com/Konloch/bytecode-viewer [Java]
 - https://github.com/java-deobfuscator/deobfuscator [Java]
-- https://github.com/gmh5225/IDA-binsync [Sync]
+- https://github.com/angr/binsync [Sync]
 
 > IDA Plugins
 - https://github.com/vmallet/ida-plugins [List of IDA Plugins]
-- https://github.com/gmh5225/IDA-IDASkins [Skins]
+- https://github.com/zyantific/IDASkins [Skins]
 - https://github.com/giladreich/ida_migrator [Migrate Database]
 - https://github.com/can1357/NtRays [Windows Kernel Enhance]
 - https://github.com/JustasMasiulis/ida_bitfields [Windows Kernel Enhance]
 - https://github.com/VoidSec/DriverBuddyReloaded [Windows Kernel Analysis]
-- https://github.com/gmh5225/IDA2Obj [COFF Relink]
-- https://github.com/gmh5225/IDA-Plugin-dotNIET [Import .NET Symbol]
+- https://github.com/jhftss/IDA2Obj [COFF Relink]
+- https://github.com/synacktiv/dotNIET [Import .NET Symbol]
 - https://github.com/aliyunav/Finger [Recognizing Function By Cloud]
-- https://github.com/gmh5225/IDA-plugin-FindFunc [Recognizing Function By Pattern]
+- https://github.com/FelixBer/FindFunc [Recognizing Function By Pattern]
 - https://github.com/kweatherman/sigmakerex [Signature Maker]
 - https://github.com/Mixaill/FakePDB [PDB Generation From IDA]
-- https://github.com/gmh5225/IDA-Ponce [Symbolic Execution]
+- https://github.com/illera88/Ponce [Symbolic Execution]
 - https://github.com/airbus-cert/ttddbg [Time Travel Debugging]
-- https://github.com/gmh5225/IDA-LazyIDA [LazyIDA]
-- https://github.com/gmh5225/IDA-qsynthesis [Greybox Synthesizer geared for deobfuscation of assembly instructions]
-- https://github.com/gmh5225/ida-medigate [RTTI]
-- https://github.com/gmh5225/findyara-ida [Yara]
-- https://github.com/gmh5225/ida-vmware_windows_gdb [IDA+VMWARE+GDB]
-- https://github.com/gmh5225/ida-bochs_windows [IDA+BOCHS]
-- [An integration for IDA and VS Code which connects both to easily execute and debug IDAPython scripts](https://github.com/gmh5225/IDA-idacode)
-- https://github.com/gmh5225/IDA-efiXplorer [UEFI firmware]
-- https://github.com/gmh5225/IDA-protobuf-finder [Protobuf]
-- https://github.com/gmh5225/IDA-golang_loader_assist [GO Reversed]
-- https://github.com/gmh5225/IDA-X64DBG-GhidraDec [Ghidra Decompiler]
-- https://github.com/gmh5225/IDA-EasyRe [Trace Execution]
+- https://github.com/P4nda0s/LazyIDA [LazyIDA]
+- https://github.com/quarkslab/qsynthesis [Greybox Synthesizer geared for deobfuscation of assembly instructions]
+- https://github.com/medigateio/ida_medigate [RTTI]
+- https://github.com/OALabs/findyara-ida [Yara]
+- https://github.com/therealdreg/ida_vmware_windows_gdb [IDA+VMWARE+GDB]
+- https://github.com/therealdreg/ida_bochs_windows [IDA+BOCHS]
+- [An integration for IDA and VS Code which connects both to easily execute and debug IDAPython scripts](https://github.com/ioncodes/idacode)
+- https://github.com/binarly-io/efiXplorer [UEFI firmware]
+- https://github.com/Accenture/protobuf-finder [Protobuf]
+- https://github.com/strazzere/golang_loader_assist [GO Reversed]
+- https://github.com/GregoryMorse/GhidraDec [Ghidra Decompiler]
+- https://github.com/AntoineBlaud/EasyRe [Trace Execution]
 
 > IDA Signature Database
-- https://github.com/gmh5225/IDA-sig-database
+- https://github.com/push0ebp/sig-database
 
 > Binary Ninja Plugins
 - https://github.com/EliseZeroTwo/SEH-Helper [SEH Helper]
 - https://github.com/Vector35/tanto [Slices Functions]
-- https://github.com/gmh5225/Binary-Ninja-triton-bn [Triton]
-- https://github.com/gmh5225/BinDiff-binexport [BinDiff]
-- https://github.com/gmh5225/Binary-Ninja-BinaryNinjaPlugins
-- https://github.com/gmh5225/binary-ninja-seninja [Symbolic Execution]
+- https://github.com/ergrelet/triton-bn [Triton]
+- https://github.com/google/binexport [BinDiff]
+- https://github.com/Pusty/BinaryNinjaPlugins
+- https://github.com/borzacchiello/seninja [Symbolic Execution]
 
 > Ghidra Plugins
-- https://github.com/gmh5225/ghidra-frida-hook-gen
+- https://github.com/CENSUS/ghidra-frida-hook-gen
 
 > Windbg Plugins
-- https://github.com/gmh5225/windbg-SwishDbgExt
-- https://github.com/gmh5225/WinDbg-comon [Trace COM]
+- https://github.com/comaeio/SwishDbgExt
+- https://github.com/lowleveldesign/comon [Trace COM]
 
 > X64DBG Plugins
 - https://github.com/x64dbg/x64dbg/wiki/Plugins
 - https://github.com/horsicq/x64dbg-Plugin-Manager
 - https://github.com/m417z/Multiline-Ultimate-Assembler
-- https://github.com/gmh5225/x64dbg-Classroom
-- https://github.com/gmh5225/x64dbg-Themidie
-- https://github.com/gmh5225/x64dbgScript
-- https://github.com/gmh5225/x64dbg-xMalHunter [Detect malicious materials]
-- https://github.com/gmh5225/x64dbg-xFindOut
-- https://github.com/gmh5225/x64dbg-chaiScriptPlugin
+- https://github.com/x64dbg/Classroom
+- https://github.com/VenTaz/Themidie
+- https://github.com/Ahmadmansoor/x64dbgScript
+- https://github.com/push0ebp/xMalHunter [Detect malicious materials]
+- https://github.com/morsisko/xFindOut
+- https://github.com/jdavidberger/chaiScriptPlugin
 - https://github.com/gmh5225/X64DBG-ViewDllNotification
-- https://github.com/gmh5225/X64DBG-AutoAttach
-- https://github.com/gmh5225/X64DBG-idenLib [Generate signatures]
-- https://github.com/gmh5225/IDA-X64DBG-GhidraDec [Ghidra Decompiler]
-- https://github.com/gmh5225/x64dbgbinja [Binary Ninja]
+- https://github.com/legendabrn/AutoAttach
+- https://github.com/secrary/idenLib [Generate signatures]
+- https://github.com/GregoryMorse/GhidraDec [Ghidra Decompiler]
+- https://github.com/x64dbg/x64dbgbinja [Binary Ninja]
 
 > Cheat Engine Plugins
-- https://github.com/gmh5225/CE-Extensions [Lua Extensions]
-- https://github.com/gmh5225/CE-lua-extensions [Lua Extensions]
-- https://github.com/gmh5225/CE-Mydev-Cheat-Engine-Tables [CT]
-- https://github.com/gmh5225/CT-Elden-Ring-CT-TGA [Elden Ring]
+- https://github.com/FreeER/CE-Extensions [Lua Extensions]
+- https://github.com/Skyrimfus/CE-lua-extensions [Lua Extensions]
+- https://github.com/bbfox0703/Mydev-Cheat-Engine-Tables [CT]
+- https://github.com/inuNorii/Elden-Ring-CT-TGA [Elden Ring]
 
 > Injection:Windows
 - https://github.com/btbd/smap [Scatter Manual Map]
@@ -506,28 +506,28 @@
 - https://github.com/wbenny/injdrv [APC]
 - https://github.com/w1u0u1/kinject [Map + APC]
 - https://github.com/andrew9382/manual_mapping_dll_injector [Manual Map]
-- https://github.com/gmh5225/Inject-MemJect [Manual Map]
+- https://github.com/danielkrupinski/MemJect [Manual Map]
 - https://github.com/can1357/ThePerfectInjector [PTE.User]
-- https://github.com/gmh5225/Driver-executor [PTE.User]
-- https://github.com/gmh5225/inject-PresentInjector [PTE.User]
-- https://github.com/gmh5225/kernel-eac-be-injector [PTE.User]
-- https://github.com/gmh5225/Driver-HVCI-KernelForge [Hijack ROP]
-- https://github.com/gmh5225/be-injector [Attack COW]
-- https://github.com/gmh5225/dll-hot-reload [Hot Reload]
-- https://github.com/gmh5225/KeUserModeCallBack [KeUserModeCallBack]
-- [KeUserModeCallBack Win10](https://github.com/gmh5225/eft/blob/834064aacaab7353173e36acc15933a3cf9289b3/eft/usercallback.h#L50)
-- https://github.com/gmh5225/Kernelmode-DLL-Injector [Manual Map]
-- [windows kernelmode driver to inject dll into each and every process and perform systemwide function hooking](https://github.com/gmh5225/driver-inject-kptnhook)
+- https://github.com/estimated1337/executor [PTE.User]
+- https://github.com/Nou4r/PresentInjector [PTE.User]
+- https://github.com/JGonz1337/kernel-eac-be-injector [PTE.User]
+- https://github.com/Cr4sh/KernelForge [Hijack ROP]
+- https://github.com/Compiled-Code/be-injector [Attack COW]
+- https://github.com/ergrelet/dll-hot-reload [Hot Reload]
+- https://github.com/ExpLife0011/KeUserModeCallBack [KeUserModeCallBack]
+- [KeUserModeCallBack Win10](https://github.com/Splitx12/eft/blob/834064aacaab7353173e36acc15933a3cf9289b3/eft/usercallback.h#L50)
+- https://github.com/YouNeverKnow00/Kernelmode-DLL-Injector [Manual Map]
+- [windows kernelmode driver to inject dll into each and every process and perform systemwide function hooking](https://github.com/sum-catnip/kptnhook)
 - https://github.com/Broihon/GH-Injector-Library [inject library and tool]
 
 > Injection:Linux
-- https://github.com/gmh5225/elf-injector-mandibule
+- https://github.com/ixty/mandibule
 
 
 > DLL Hijack
-- https://github.com/gmh5225/DLL-Hijack-DLLirant [Hijacking researches]
-- https://github.com/gmh5225/DLLHijack-ImpulsiveDLLHijack [Hijacking researches]
-- https://github.com/gmh5225/HijackLibs [Project for tracking publicly disclosed DLL Hijacking opportunities]
+- https://github.com/Sh0ckFR/DLLirant [Hijacking researches]
+- https://github.com/knight0x07/ImpulsiveDLLHijack [Hijacking researches]
+- https://github.com/wietze/HijackLibs [Project for tracking publicly disclosed DLL Hijacking opportunities]
 
 > Hook
 - https://github.com/microsoft/Detours
@@ -535,22 +535,22 @@
 - https://github.com/stevemk14ebr/PolyHook
 - https://github.com/stevemk14ebr/PolyHook_2_0
 - https://github.com/WopsS/RenHook
-- https://github.com/gmh5225/Android-hook-PyAsmPatch
-- https://github.com/gmh5225/Driver-KDtour [Easy Kernel Detour]
-- https://github.com/gmh5225/PAGE_GUARD-PGHooker [Page Guard]
-- https://github.com/gmh5225/HOOK-SkipHook [Skip Hook]
-- https://github.com/gmh5225/gdi32-data-hook-edgegdi_hook [gdi32 .data swap]
+- https://github.com/axhlzy/PyAsmPatch
+- https://github.com/TupleDev/KDtour [Easy Kernel Detour]
+- https://github.com/nelfo/PGHooker [Page Guard]
+- https://github.com/weak1337/SkipHook [Skip Hook]
+- https://github.com/0mdi/edgegdi_hook [gdi32 .data swap]
 
 > Rop Finder
-- https://github.com/gmh5225/ROP-rp
+- https://github.com/0vercl0k/rp
 
 > Anti Signature Scanning
-- https://github.com/gmh5225/AV-BYPASS-TEST-avdebugger
+- https://github.com/scrt/avdebugger
 
 > RPM
 - https://github.com/btbd/access
-- https://github.com/gmh5225/Driver-access-intraceptor [access]
-- https://github.com/gmh5225/readwrite-kernel-stable
+- https://github.com/crvvdev/intraceptor [access]
+- https://github.com/juniorjacob/readwrite-kernel-stable
 - https://github.com/DarthTon/Blackbone
 - https://github.com/HoShiMin/Kernel-Bridge
 - https://github.com/waryas/EUPMAccess
@@ -560,81 +560,81 @@
 - https://github.com/SamuelTulach/efi-memory [EFI RPM]
 - https://www.unknowncheats.me/forum/anti-cheat-bypass/489305-read-write-process-attach.html
 - https://www.unknowncheats.me/forum/anti-cheat-bypass/444289-read-process-physical-memory-attach.html
-- https://github.com/gmh5225/linux-mempeek [Linux]
-- https://github.com/gmh5225/meme-rw [kdmapper]
+- https://github.com/gamozolabs/mempeek [Linux]
+- https://github.com/SamuelTulach/meme-rw [kdmapper]
 
 > W2S
 - https://github.com/DrNseven/D3D11-Worldtoscreen-Finder
 
 > Overlay
 - https://github.com/coltonon/D2DOverlay
-- https://github.com/gmh5225/Direct3D9-Overlay [DX9]
+- https://github.com/SeanPesce/Direct3D9-Overlay [DX9]
 - https://github.com/Unkn0wnH4ck3r/GameOverlayUIHook [Steam]
-- https://github.com/gmh5225/Steam-Hook-Render-PoC [Steam]
-- https://github.com/gmh5225/steam-overlay-x64 [Steam]
-- https://github.com/gmh5225/KGDI-steamoverlay-StrongSteam [GDI + Steam]
+- https://github.com/Xenia0/Steam-Hook-Render-PoC [Steam]
+- https://github.com/xo1337/steam-overlay-x64 [Steam]
+- https://github.com/Splitx12/StrongSteam [GDI + Steam]
 - https://github.com/gmh5225/dwmhook [DWM]
-- https://github.com/gmh5225/dwm-overlay [DWM]
-- https://github.com/gmh5225/dwmhook-vft [DWM VFTable]
-- https://github.com/gmh5225/overlay-nvidia-overlay-hijack [Hijack Nvidia]
-- https://github.com/gmh5225/D3DOverlay-Nvidia-Hijack [Hijack Nvidia]
-- https://github.com/gmh5225/nvidia-overlay-renderer [Nvidia]
-- https://github.com/gmh5225/overlay-SetWindowsHookEx [SetWindowsHookEx]
+- https://github.com/LoxTus/dwm-overlay [DWM]
+- https://github.com/mfxiaosheng/dwmhook [DWM VFTable]
+- https://github.com/iraizo/nvidia-overlay-hijack [Hijack Nvidia]
+- https://github.com/Brattlof/D3DOverlay-Nvidia-Hijack [Hijack Nvidia]
+- https://github.com/es3n1n/nvidia-overlay-renderer [Nvidia]
+- https://github.com/muturikaranja/overlay [SetWindowsHookEx]
 - https://github.com/gmh5225/OBS-graphics-hook32-Hook [OBS Hook]
-- https://github.com/gmh5225/OBS-Hook [OBS Hook]
-- https://github.com/gmh5225/overlay-gdi-NotAnOverlay [GDI Overlay]
+- https://github.com/plu1337/OBS-Hook [OBS Hook]
+- https://github.com/PierreCiholas/NotAnOverlay [GDI Overlay]
 
 > Render/Draw
 - https://github.com/vmcall/dxgkrnl_hook
-- https://github.com/gmh5225/Driver-krnl-gdi-render [Dxgkrnl + GDI]
-- https://github.com/gmh5225/KernelGDIDraw
-- https://github.com/gmh5225/KGDI-steamoverlay-StrongSteam [GDI + Steam]
-- https://github.com/gmh5225/Driver-KernelDrawing [Drawing from kernelmode without any hooks]
-- https://github.com/gmh5225/Driver-DoubleCallBack [DWM In Kernel]
-- https://github.com/gmh5225/imgui-android-PolarImGui [Imgui On Android]
-- https://github.com/gmh5225/Android-Mod-Menu [Floating mod menu for Android]
-- https://github.com/gmh5225/imgui-Unity-With-Layout [Imgui For Unity]
-- https://github.com/gmh5225/IL2CPP-GUI-BepInEx-IL2CPPBase [IL2CPP Menu]
+- https://github.com/r1cky33/krnl-gdi-render [Dxgkrnl + GDI]
+- https://github.com/BadPlayer555/KernelGDIDraw
+- https://github.com/Splitx12/StrongSteam [GDI + Steam]
+- https://github.com/Sentient111/KernelDrawing [Drawing from kernelmode without any hooks]
+- https://github.com/wbaby/DoubleCallBack [DWM In Kernel]
+- https://github.com/Polarmods/PolarImGui [Imgui On Android]
+- https://github.com/LGLTeam/Android-Mod-Menu [Floating mod menu for Android]
+- https://github.com/springmusk026/ImGui-Unity-With-Layout [Imgui For Unity]
+- https://github.com/VerityIncorporated/BepInEx-IL2CPPBase [IL2CPP Menu]
 
 > UI Interface
 - https://github.com/adamhlt/ImGui-Standalone
 
 > Vulnerable Driver 
 - https://github.com/hacksysteam/HackSysExtremeVulnerableDriver [Guide]
-- https://github.com/gmh5225/windows-kernel-exploits [Guide]
-- https://github.com/gmh5225/Exploit-vulnerable-physmem_drivers [Vulnerable Driver List]
-- https://github.com/gmh5225/Exploit-drivers_and_shit [Vulnerable Driver List]
-- https://github.com/gmh5225/vulnerable-driver-scanner [Scans for vulnerable drivers]
-- https://github.com/kkent030315/gdrv-loader/tree/1909_mitigation [gdrv.sys]
+- https://github.com/xct/windows-kernel-exploits [Guide]
+- https://github.com/namazso/physmem_drivers [Vulnerable Driver List]
+- https://github.com/alfarom256/drivers_and_shit [Vulnerable Driver List]
+- https://github.com/Xxmmy/vulnerable-driver-scanner [Scans for vulnerable drivers]
+- https://github.com/fengjixuchui/gdrv-loader/tree/1909_mitigation [gdrv.sys]
 - http://rexw3wrz5pldtadf3hy4vqnuzokhco4l32kyntj36fcgpjuy3nvxidid.onion/_xeroxz/VDM [gdrv enhance]
-- https://github.com/gmh5225/eac-mapper [gdrv.sys]
-- https://github.com/gmh5225/kdmapper [iqvw64e.sys]
+- https://github.com/Compiled-Code/eac-mapper [gdrv.sys]
+- https://github.com/eddeeh/kdmapper [iqvw64e.sys]
 - https://github.com/TheCruZ/kdmapper [iqvw64e.sys]
-- https://github.com/gmh5225/Driver-kdmapper-1909 [iqvw64e.sys]
+- https://github.com/Brattlof/kdmapper-1909 [iqvw64e.sys]
 - https://github.com/kkent030315/MsIoExploit [MsIo64.sys]
 - https://github.com/kkent030315/evil-mhyprot-cli [Mhyprot2.sys]
-- https://github.com/gmh5225/evil-mhyprot-cli [Mhyprot2.sys]
-- https://github.com/gmh5225/mhyprot2 [Mhyprot2.sys]
-- https://github.com/gmh5225/Mhyprot2DrvControl [Mhyprot2.sys]
-- https://github.com/gmh5225/AvastHV [Avast]
-- https://github.com/gmh5225/KasperskyHook [Kaspersky]
-- https://github.com/gmh5225/CVE-2021-21551 [dbutil_2_3.sys]
-- https://github.com/gmh5225/Driver-imxyviMapper [AsUpIO.sys]
-- https://github.com/gmh5225/vdk [Speedfan.sys]
-- https://github.com/gmh5225/SpeedFan-Exploit [Speedfan.sys]
-- https://github.com/gmh5225/Exploit-Vulnerable-CapcomLib [Capcom.sys]
-- https://github.com/gmh5225/capcom-dolboeb-executor [Capcom.sys]
-- https://github.com/gmh5225/CVE-2015-2291 [IQVW64.sys]
-- https://github.com/gmh5225/Exploit-AsIO-Exploit [AsIO3.sys]
+- https://github.com/leeza007/evil-mhyprot-cli [Mhyprot2.sys]
+- https://github.com/keowu/mhyprot2 [Mhyprot2.sys]
+- https://github.com/kagurazakasanae/Mhyprot2DrvControl [Mhyprot2.sys]
+- https://github.com/tanduRE/AvastHV [Avast]
+- https://github.com/iPower/KasperskyHook [Kaspersky]
+- https://github.com/mathisvickie/CVE-2021-21551 [dbutil_2_3.sys]
+- https://github.com/Splitx12/imxyviMapper [AsUpIO.sys]
+- https://github.com/archercreat/vdk [Speedfan.sys]
+- https://github.com/SamLarenN/SpeedFan-Exploit [Speedfan.sys]
+- https://github.com/Gbps/CapcomLib [Capcom.sys]
+- https://github.com/es3n1n/dolboeb-executor [Capcom.sys]
+- https://github.com/Exploitables/CVE-2015-2291 [IQVW64.sys]
+- https://github.com/KiFilterFiberContext/AsIO-Exploit [AsIO3.sys]
 
 
 > Driver Communication
 - https://github.com/gmh5225/Driver-Communication-List
 - https://github.com/EBalloon/Common-Registry [Registry Callback]
 - https://github.com/gmh5225/Common-Registry-Jmp-RCX [Registry Callback]
-- https://github.com/gmh5225/BOOM [Hijack Beep.sys]
-- https://github.com/gmh5225/Driver-read_write [Hijack IRP]
-- https://github.com/gmh5225/Comm-Swap-control-ioctl [Hijack IRP SpeedFan.sys]
+- https://github.com/zoand/BOOM [Hijack Beep.sys]
+- https://github.com/hrt/read_write [Hijack IRP]
+- https://github.com/Barracudach/Swap-control-ioctl [Hijack IRP SpeedFan.sys]
 - https://github.com/adspro15/km-um-communication
 - https://github.com/Spuckwaffel/Kernel-Thread-Driver [Thread]
 - https://github.com/Astronaut00/DoubleDataPointer [Double Data Pointer]
@@ -643,29 +643,29 @@
 - https://github.com/weak1337/EvCommunication [NtTokenManagerCreateFlipObjectReturnTokenHandle]
 - https://github.com/UCFoxi/Shared-FlushFileBuffers-Communication [FlushFileBuffers]
 - https://github.com/Sinclairq/DataCommunication [NtCompareSigningLevels]
-- https://github.com/gmh5225/NtCompareSigningLevel-hook [NtCompareSigningLevels]
-- https://github.com/gmh5225/AfdIrpCallDispatch [.data Pointer hook in Afd.sys]
+- https://github.com/ExpLife0011/NtCompareSigningLevel-hook [NtCompareSigningLevels]
+- https://github.com/muturikaranja/AfdIrpCallDispatch [.data Pointer hook in Afd.sys]
 - https://www.unknowncheats.me/forum/anti-cheat-bypass/483093-vtable-kernel-function-hook-communication.html [NtUserMessageCall]
-- https://github.com/gmh5225/Driver-MapPage [NtUserGetObjectInformation]
-- https://github.com/gmh5225/eac-mapper [NtMapVisualRelativePoints]
+- https://github.com/EBalloon/MapPage [NtUserGetObjectInformation]
+- https://github.com/Compiled-Code/eac-mapper [NtMapVisualRelativePoints]
 - https://git.back.engineering/_xeroxz/NtWin32k [NtUserGetThreadState]
-- https://github.com/gmh5225/Common-boundcallback [KeRegisterBoundCallback]
-- https://github.com/gmh5225/DataPtrSwap-driver [NtSetCompositionSurfaceAnalogExclusive]
-- https://github.com/gmh5225/.data-ptr-swap [NtSetCompositionSurfaceAnalogExclusive]
-- https://github.com/gmh5225/Driver-ReadWriteDriver [NtUserSetSysColors]
-- https://github.com/gmh5225/NtUserUpdateWindowTrackingInfo [NtUserUpdateWindowTrackingInfo]
-- https://github.com/gmh5225/comm-windows-software-policy [clip]
+- https://github.com/sbsbsbssbsbs/boundcallback [KeRegisterBoundCallback]
+- https://github.com/Skengdoo/DataPtrSwap-driver [NtSetCompositionSurfaceAnalogExclusive]
+- https://github.com/xPasters/.data-ptr-swap [NtSetCompositionSurfaceAnalogExclusive]
+- https://github.com/ryan-weil/ReadWriteDriver [NtUserSetSysColors]
+- https://github.com/D3DXVECTOR2/NtUserUpdateWindowTrackingInfo [NtUserUpdateWindowTrackingInfo]
+- https://github.com/KiFilterFiberContext/windows-software-policy [clip]
 - https://github.com/gmh5225/Interep-Driver-Leak [NtGdiPolyPolyDraw]
-- https://github.com/gmh5225/Comm-data-ptr-driver [NtGdiPolyPolyDraw]
-- https://github.com/gmh5225/comm-kernel-eac-be-comm [NtGdiPolyPolyDraw]
-- https://github.com/gmh5225/Comm-NullHook [NtDxgkGetTrackedWorkloadStatistics]
-- https://github.com/gmh5225/Comm-Data-Pointer-Swap [NtDCompositionSetChildRootVisual]
-- https://github.com/gmh5225/Comm-NekoSwap [Win32kApiSetTable]
-- https://github.com/gmh5225/Comm-kernel_payload_comms [Shared Memory]
-- https://github.com/gmh5225/Valorant-UCMiraka-ValorantExternal [NtUserGetPointerProprietaryId]
+- https://github.com/TupleDev/.data-ptr-driver [NtGdiPolyPolyDraw]
+- https://github.com/JGonz1337/kernel-eac-be-comm [NtGdiPolyPolyDraw]
+- https://github.com/NullTerminatorr/NullHook [NtDxgkGetTrackedWorkloadStatistics]
+- https://github.com/SurgeGotTappedAgain/Data-Pointer-Swap [NtDCompositionSetChildRootVisual]
+- https://github.com/SamuelTulach/NekoSwap [Win32kApiSetTable]
+- https://github.com/Deputation/kernel_payload_comms [Shared Memory]
+- https://github.com/Chase1803/UCMiraka-ValorantExternal [NtUserGetPointerProprietaryId]
 
 > EFI Driver
-- https://github.com/gmh5225/EFI-EasyUefi [Visual Studio template for GNU-EFI]
+- https://github.com/SamuelTulach/EasyUefi [Visual Studio template for GNU-EFI]
 - https://github.com/btbd/umap [EFI Manual Map]
 - https://github.com/ekknod/sumap [EFI Manual Map]
 - https://github.com/ekknod/KiSystemStartupMeme [Custom KiSystemStartup]
@@ -673,22 +673,22 @@
 - https://github.com/TheCruZ/EFI_Driver_Access [RPM]
 - https://github.com/SecIdiot/bootkit
 - https://github.com/SamuelTulach/rainbow [HWID]
-- https://github.com/gmh5225/-Rainbow---EFI [HWID]
-- https://github.com/gmh5225/Fortnite-EFI-External [Fortnite]
-- https://github.com/gmh5225/UEFI-Bootkit
-- https://github.com/gmh5225/EFI-HWID-negativespoofer [HWID]
+- https://github.com/firebitsbr/-Rainbow---EFI [HWID]
+- https://github.com/Kiaoee/Fortnite-EFI-External [Fortnite]
+- https://github.com/ajkhoury/UEFI-Bootkit
+- https://github.com/SamuelTulach/negativespoofer [HWID]
 
 > QEMU/KVM Cheat
 - https://github.com/memflow/memflow-kvm
 - https://github.com/MisterY52/apex_dma_kvm_pub
 - https://github.com/SamuelTulach/BetterTiming [Bypass CPU Timing]
-- https://github.com/gmh5225/qemu-hide-Hardened-qemu [Hidden QEMU]
-- https://github.com/gmh5225/QEMU-Nyx [Intel-PT]
-- https://github.com/gmh5225/KVM-Tools/blob/master/Virtualization/kvm-qemu.sh [QEMU Script]
-- https://github.com/gmh5225/QEMU-Malware-Behavior-Analyzer-MBA [QEMU Malware Behavior Analyzer]
+- https://github.com/batusan/Hardened-qemu [Hidden QEMU]
+- https://github.com/nyx-fuzz/QEMU-Nyx [Intel-PT]
+- https://github.com/doomedraven/Tools/blob/master/Virtualization/kvm-qemu.sh [QEMU Script]
+- https://github.com/GlacierW/MBA [QEMU Malware Behavior Analyzer]
 
 > Wine
-- https://github.com/gmh5225/wine-Proton [Steam]
+- https://github.com/ValveSoftware/Proton [Steam]
 
 > Anti Screenshot
 - https://github.com/KANKOSHEV/NoScreen [Hide Window]
@@ -696,16 +696,16 @@
 - https://github.com/wongfei/wda_monitor_trick
 
 > Spoof Stack
-- https://github.com/gmh5225/ThreadStackSpoofer
-- https://github.com/gmh5225/x86RetSpoof
-- https://github.com/gmh5225/return-address-spoofing
-- https://github.com/gmh5225/Exception-Ret-Spoofing
-- https://github.com/gmh5225/Ret-Spoofing
-- https://github.com/gmh5225/CallStackSpoofer
-- https://github.com/gmh5225/spoof-CallStack-Spoofer
-- https://github.com/gmh5225/spoof-NimicStack
-- https://github.com/gmh5225/spoof-callout-poc
-- https://github.com/gmh5225/Return-address-spoofer
+- https://github.com/mgeeky/ThreadStackSpoofer
+- https://github.com/danielkrupinski/x86RetSpoof
+- https://github.com/Apex-master/return-address-spoofing
+- https://github.com/Peribunt/Exception-Ret-Spoofing
+- https://github.com/Peribunt/Ret-Spoofing
+- https://github.com/WithSecureLabs/CallStackSpoofer
+- https://github.com/Barracudach/CallStack-Spoofer
+- https://github.com/frkngksl/NimicStack
+- https://github.com/thesecretclub/callout-poc
+- https://github.com/veryboreddd/Return-address-spoofer
 
 > Hide
 - https://github.com/JKornev/hidden
@@ -718,33 +718,33 @@
 - https://github.com/VollRagm/lpmapper [Manual Map To Large Page Driver]
 - https://github.com/armvirus/CosMapper [Signed Driver Map]
 - https://github.com/gmh5225/HideDriverTesting [Hide Driver]
-- https://github.com/gmh5225/TraceCleaner [Driver Trace Cleaner]
-- https://github.com/gmh5225/Driver-ClearDriverTraces [Driver Trace Cleaner]
+- https://github.com/BadPlayer555/TraceCleaner [Driver Trace Cleaner]
+- https://github.com/Sentient111/ClearDriverTraces [Driver Trace Cleaner]
 - https://github.com/KelvinMsft/NoTruth [Hide Memory By VT]
-- https://github.com/gmh5225/Driver-MapPage [Self Map Driver]
-- https://github.com/gmh5225/eac-mapper [Self Map Driver]
-- https://github.com/gmh5225/HideDriver-flink-blink [Hide Driver By Modify Flink/Blink]
-- https://github.com/gmh5225/HideDriver-MiProcessLoaderEntry [Hide Driver By MiProcessLoaderEntryk]
+- https://github.com/EBalloon/MapPage [Self Map Driver]
+- https://github.com/Compiled-Code/eac-mapper [Self Map Driver]
+- https://github.com/nbqofficial/HideDriver [Hide Driver By Modify Flink/Blink]
+- https://github.com/ExpLife0011/HideDriver [Hide Driver By MiProcessLoaderEntryk]
 - https://github.com/gmh5225/Driver-HideKernelThread-IoCancelIrp [Hide Kernel Thread]
-- https://github.com/gmh5225/Hide-Driver-Thread-blanket [Hide Kernel Thread]
-- https://github.com/gmh5225/hide-herpaderping [Hide Process/File]
-- https://github.com/gmh5225/hide-thread-address-KaynStrike [Spoofs Thread Start Address]
+- https://github.com/kitty8904/blanket [Hide Kernel Thread]
+- https://github.com/jxy-s/herpaderping [Hide Process/File]
+- https://github.com/Cracked5pider/KaynStrike [Spoofs Thread Start Address]
 - [Using .reloc section to replace the typical allocation calls](https://github.com/gmh5225/memory-relocalloc)
-- https://github.com/gmh5225/android-hideroot [Magisk]
-- https://github.com/gmh5225/hide-system-thread-Diglett [Hide Kernel Thread]
+- https://github.com/longpoxin/hideroot [Magisk]
+- https://github.com/Rwkeith/Diglett [Hide Kernel Thread]
 
 > Triggerbot & Aimbot
 - https://github.com/changeofpace/MouHidInputHook
 - https://github.com/blackhades00/PareidoliaTriggerbot
 - https://github.com/adspro15/DirectInput
-- https://github.com/gmh5225/CSGO-norsefire
+- https://github.com/nbqofficial/norsefire
 - https://github.com/lucylow/b00m-h3adsh0t [Neural Network]
 - https://github.com/univrsal/input-overlay [Keyboard Mapper]
 - https://github.com/Miffyli/gan-aimbots [Machine Learning]
-- https://github.com/gmh5225/camera-triggerbot [Camera Triggerbot]
-- https://github.com/gmh5225/Driver-KernelMoveMouse [gptCursorAsync]
-- https://github.com/gmh5225/mouse-input-injection [NtUserInjectMouseInput]
-- https://github.com/gmh5225/Overwatch-1-cheat-source [NtUserInjectMouseInput]
+- https://github.com/lehmenkuehler/camera-triggerbot [Camera Triggerbot]
+- https://github.com/BuddyBoi/KernelMoveMouse [gptCursorAsync]
+- https://github.com/Zpes/mouse-input-injection [NtUserInjectMouseInput]
+- https://github.com/OSNSON/Overwatch-1-cheat-source-. [NtUserInjectMouseInput]
 - https://github.com/gmh5225/NtUserInjectMouseInput-syscall [NtUserInjectMouseInput SYSCALL]
 
 > WallHack
@@ -752,7 +752,7 @@
 
 > HWID
 - https://github.com/dword64/Ow-Anti-Flag
-- https://github.com/gmh5225/hwid
+- https://github.com/btbd/hwid
 - https://github.com/lil-skies/btbd-modified
 - https://github.com/xEnething/Permanent-HWID-Spoofer
 - https://github.com/Theordernarkoz/Hwid-Spoofer-EAC-BE
@@ -762,38 +762,38 @@
 - https://github.com/SarnaxLii/Apex-ClearTrace
 - https://github.com/lil-skies/btbd-modified
 - https://github.com/InstinctTheDevil/EclipsedSpoofer-EAC-BE
-- https://github.com/gmh5225/HWID-SpooferEAC
+- https://github.com/BuzzerFelix/HWIDSpooferEAC
 - https://github.com/SamuelTulach/rainbow [EFI]
-- https://github.com/gmh5225/-Rainbow---EFI [EFI]
+- https://github.com/firebitsbr/-Rainbow---EFI [EFI]
 - https://github.com/btbd/wpp [Intercepting DeviceControl via WPP]
-- https://github.com/gmh5225/Driver-owned_alignment [Abusing Alignment]
+- https://github.com/vmcall/owned_alignment [Abusing Alignment]
 - https://github.com/gmh5225/Hwid-Spoofer-Valorant-Eac-Be-Vanguard-Permanted-Temporary-Spoofer
-- https://github.com/gmh5225/Hwid-Spoofer-Game-Anticheat-Cleaners-Unban-Any-Games-Drivers
-- https://github.com/gmh5225/HWID-Kernel-Spoofer
-- [HWID-Spoofer-UD-Fortnite-WarZone-Apex-Rust-Escape-From-Tarkov-and-all-EAC-BE-Games-IMGUI-Loader-Base](https://github.com/gmh5225/HWID-Spoofer-UD-Fortnite-WarZone-Apex-Rust-Escape-From-Tarkov-and-all-EAC-BE-Games-IMGUI-Loader-Base)
-- https://github.com/gmh5225/HWID-mutante
-- https://github.com/gmh5225/HWID-ImGui-Spoofer-Leaked
-- https://github.com/gmh5225/HWID-Spoofer-for-Fortnite-and-Valorant
-- https://github.com/gmh5225/HWID-Full-Hwid-Spoofer-V6
-- https://github.com/gmh5225/HWID-SteamSpywareTerminator [Steam]
-- https://github.com/gmh5225/EFI-HWID-negativespoofer [EFI]
-- https://github.com/gmh5225/wmi-static-spoofer
+- https://github.com/mopped7/Hwid-Spoofer-Game-Anticheat-Cleaners-Unban-Any-Games-Drivers
+- https://github.com/StHomeLess/HWID-Kernel-Spoofer
+- [HWID-Spoofer-UD-Fortnite-WarZone-Apex-Rust-Escape-From-Tarkov-and-all-EAC-BE-Games-IMGUI-Loader-Base](https://github.com/KakashiiiSan/HWID-Spoofer-UD-Fortnite-WarZone-Apex-Rust-Escape-From-Tarkov-and-all-EAC-BE-Games-IMGUI-Loader-Base)
+- https://github.com/SamuelTulach/mutante
+- https://github.com/Veuqx0/ImGui-Spoofer-Leaked
+- https://github.com/gupr0x4/HWID-Spoofer-for-Fortnite-and-Valorant
+- https://github.com/archie2adolphe/Full-Hwid-Spoofer-V6
+- https://github.com/Lyut/SteamSpywareTerminator [Steam]
+- https://github.com/SamuelTulach/negativespoofer [EFI]
+- https://github.com/Alex3434/wmi-static-spoofer
 
 > Bypass Page Protection
 - https://github.com/illegal-instruction-co/CountHook [WorkingSet]
 
 > SDK CodeGen
-- https://github.com/gmh5225/codegen-sdkgenny
-- https://github.com/gmh5225/sdk-gen-luagenny
+- https://github.com/cursey/sdkgenny
+- https://github.com/praydog/luagenny
 
 > Game Engine Explorer:Unreal
-- https://github.com/gmh5225/UE4-shootergame-Hack [ShooterGame Demo]
+- https://github.com/asjbdkabs/shootergame-Hack [ShooterGame Demo]
 - https://github.com/Shhoya/Shh0yaUEDumper [SDK Dump]
 - https://github.com/guttir14/UnrealDumper-4.25 [SDK Dump]
-- https://github.com/gmh5225/UE-UEDumper [SDK Dump]
-- https://github.com/gmh5225/UE4Dumper [SDK Dump For Android]
-- https://github.com/gmh5225/UE-UE4Dumper_Emulator [SDK Dump For Android]
-- https://github.com/gmh5225/iOS_UE4Dumper [SDK Dump For IOS]
+- https://github.com/EZFNDEV/UEDumper [SDK Dump]
+- https://github.com/kp7742/UE4Dumper [SDK Dump For Android]
+- https://github.com/Zakaria-Master/UE4Dumper_Emulator [SDK Dump For Android]
+- https://github.com/MJx0/iOS_UE4Dumper [SDK Dump For IOS]
 - https://github.com/CorrM/Unreal-Finder-Tool [SDK View]
 - https://github.com/spudgy/UnrealEngine4-SwissKnife [SDK View]
 - https://github.com/shalzuth/UnrealSharp [SDK View]
@@ -801,113 +801,113 @@
 - https://github.com/cursey/ue4genny [SDK Generator]
 - https://github.com/Zebratic/UE4Injector [Inject]
 - https://github.com/N-T33/UE4-Silent-Aim [Aimbot]
-- https://github.com/gmh5225/UE-ue4_base [SDK Template]
-- https://github.com/gmh5225/UE-UE4-Freecam [FOV Changer]
-- https://github.com/gmh5225/UE-UnrealModLoader [Mod Loader]
-- [Intercept ProcessEvent calls on any game object (Unreal Engine 4)](https://github.com/gmh5225/ue4-processevent-intercept)
-- [UE4 Cheat Source Code](https://github.com/gmh5225/UE4-Cheat-Source-Code)
-- https://github.com/gmh5225/ue4-android-cheat_engine [UE4 Cheat For Android]
+- https://github.com/YMY1666527646/ue4_base [SDK Template]
+- https://github.com/percpopper/UE4-Freecam [FOV Changer]
+- https://github.com/RussellJerome/UnrealModLoader [Mod Loader]
+- [Intercept ProcessEvent calls on any game object (Unreal Engine 4)](https://github.com/Skengdo/ue4-processevent-intercept)
+- [UE4 Cheat Source Code](https://github.com/1hAck-0/UE4-Cheat-Source-Code)
+- https://github.com/bbgsm/ue4_cheat_engine [UE4 Cheat For Android]
 
 > Game Engine Explorer:Unity
 - https://github.com/mono/mono [mono]
-- https://github.com/gmh5225/Unity-dnSpy-Unity-mono [mono]
-- https://github.com/gmh5225/Mono.Debugger.Soft [Mono Debugger]
+- https://github.com/dnSpy/dnSpy-Unity-mono [mono]
+- https://github.com/dnSpy/Mono.Debugger.Soft [Mono Debugger]
 - https://github.com/Perfare/Il2CppDumper [Il2Cpp Dump]
-- https://github.com/gmh5225/Il2CppDumper-YuanShen [Il2Cpp Dump for Genshin Impact]
-- https://github.com/T5ive/Il2CppDumper-GUI [Il2Cpp Dump GUI]
+- https://github.com/khang06/Il2CppDumper-YuanShen [Il2Cpp Dump for Genshin Impact]
+- https://github.com/Perfare/Il2CppDumper [Il2Cpp Dump GUI]
 - https://github.com/shalzuth/Il2CppRuntimeDumper [Il2Cpp Dump Runtime]
 - https://github.com/Perfare/Zygisk-Il2CppDumper [Il2Cpp Dump for Android Platform]
-- https://github.com/gmh5225/IL2CPPDumper [Il2Cpp Dump for Android Platform]
-- https://github.com/gmh5225/Android-Il2cppSpy [Unity IL2CPP Disassembler (for apk)]
+- https://github.com/kp7742/IL2CPPDumper [Il2Cpp Dump for Android Platform]
+- https://github.com/yukiarrr/Il2cppSpy [Unity IL2CPP Disassembler (for apk)]
 - https://github.com/djkaty/Il2CppInspector [Il2Cpp Dump]
 - https://github.com/sinai-dev/UnityExplorer
 - https://github.com/4ch12dy/il2cpp [Il2Cpp Version]
 - https://github.com/nneonneo/Il2CppVersions [Il2Cpp Version]
 - https://github.com/sneakyevilSK/IL2CPP_Resolver
 - https://github.com/knah/Il2CppAssemblyUnhollower
-- https://github.com/gmh5225/mono-external-lib [External Mono Example]
-- https://github.com/gmh5225/external-il2cpp [Il2Cpp]
-- https://github.com/gmh5225/Il2CppSDKGenerator [Il2Cpp SDK generator for Android]
-- https://github.com/gmh5225/UnityDecompiled [An unofficial repo of decompiled Unity dll files]
-- https://github.com/gmh5225/Il2CppAssemblyUnhollower [Managed->IL2CPP proxy assemblies]
-- https://github.com/gmh5225/MegaDumper [Dump native and .NET assemblies]
-- https://github.com/gmh5225/UABE [Extracting assets]
+- https://github.com/reahly/mono-external-lib [External Mono Example]
+- https://github.com/Compiled-Code/external-il2cpp [Il2Cpp]
+- https://github.com/Octowolve/Il2CppSDKGenerator [Il2Cpp SDK generator for Android]
+- https://github.com/00christian00/UnityDecompiled [An unofficial repo of decompiled Unity dll files]
+- https://github.com/knah/Il2CppAssemblyUnhollower [Managed->IL2CPP proxy assemblies]
+- https://github.com/CodeCracker-Tools/MegaDumper [Dump native and .NET assemblies]
+- https://github.com/SeriousCache/UABE [Extracting assets]
 - https://devxdevelopment.com/Unpacker [Extracting assets]
-- https://github.com/gmh5225/AssetRipper [Extracting assets]
-- https://github.com/gmh5225/Unity-AssetStudio [Extracting assets]
-- https://github.com/gmh5225/Il2Cpp-HookScripts [Il2Cpp Hook Scripts]
-- https://github.com/gmh5225/CSharp-patch-ACEPatcher [.NET Patcher]
+- https://github.com/AssetRipper/AssetRipper [Extracting assets]
+- https://github.com/Perfare/AssetStudio [Extracting assets]
+- https://github.com/axhlzy/Il2CppHookScripts [Il2Cpp Hook Scripts]
+- https://github.com/BataBo/ACEPatcher [.NET Patcher]
 
 > Game Engine Explorer:Source
-- https://github.com/gmh5225/Source2Dumps [Dump]
+- https://github.com/anarh1st47/Source2Dumps [Dump]
 
 > Explore UWP
-- https://github.com/gmh5225/UWP-UWPDumper
+- https://github.com/Wunkolo/UWPDumper
 
 > Explore AntiCheat System:VAC
 - https://github.com/danielkrupinski/VAC-Bypass-Loader
-- https://github.com/gmh5225/vac-hooks
-- https://github.com/gmh5225/VAC-Shtreeba [Injector]
+- https://github.com/danielkrupinski/vac-hooks
+- https://github.com/mdilai/Shtreeba [Injector]
 
 > Explore AntiCheat System:EAC
 - https://github.com/thesecretclub/CVEAC-2020 [Integrity Checks]
 - https://github.com/Schnocker/EAC_dbp [Debug]
-- https://github.com/gmh5225/eac-mapper [Eac Mapper]
-- https://github.com/gmh5225/EAC-MmCopyMemory-EAC [Bypass MmCopyMemory]
+- https://github.com/Compiled-Code/eac-mapper [Eac Mapper]
+- https://github.com/EBalloon/MmCopyMemory [Bypass MmCopyMemory]
 - https://github.com/gmh5225/EAC-Kernel-Packet-Fucker [Packet Fucker]
-- https://github.com/gmh5225/EAC-HydraHook [Packet Fucker]
-- https://github.com/gmh5225/EAC-EazyAntiCheatSRC [Reversed Source]
-- https://github.com/gmh5225/eac-leak [EAC sdk's memory leak]
-- https://github.com/gmh5225/Eac-Bypass
-- https://github.com/gmh5225/EasyAntiCheat-SRC
+- https://github.com/TupleDev/HydraHook [Packet Fucker]
+- https://github.com/woomy144/EazyAntiCheatSRC [Reversed Source]
+- https://github.com/chaeyk/eac-leak [EAC sdk's memory leak]
+- https://github.com/ksoju/Eac-Bypass
+- https://github.com/EBalloon/EasyAntiCheat-SRC
 - https://www.unknowncheats.me/forum/anti-cheat-bypass/458928-eacs-maskable-interrupt-callback.html [NMI]
 - https://www.unknowncheats.me/forum/anti-cheat-bypass/464943-eac-nmi-bypass-callbacks.html [NMI Bypass]
-- https://github.com/gmh5225/EAC-EasyAntiCheat-Reversing
-- https://github.com/gmh5225/EAC-hiearchy-eac [Integrity Checks]
-- https://github.com/gmh5225/EAC_Emu [Simple EasyAntiCheat x64 emulator]
+- https://github.com/CheeZeDark/EasyAntiCheat-Reversing
+- https://github.com/Sinclairq/hiearchy-eac [Integrity Checks]
+- https://github.com/Rat431/EAC_Emu [Simple EasyAntiCheat x64 emulator]
 
 > Explore AntiCheat System:BE
-- https://github.com/gmh5225/BE-NoEye
+- https://github.com/Schnocker/NoEye
 - https://github.com/unreaIuser/BE-Emulator
 - https://github.com/masterpastaa/BattlEye-Handler-BYPASS
-- https://github.com/gmh5225/battleye-decryption
-- https://github.com/gmh5225/BE-bedaisy-reversal
-- https://github.com/gmh5225/battleye-shellcode
-- https://github.com/gmh5225/be-injector [Attack COW]
-- https://github.com/gmh5225/BE-BEDaisy
-- https://github.com/gmh5225/BadEye
-- https://github.com/gmh5225/BE-BlindEye [Packet Fucker]
-- https://github.com/gmh5225/goodeye
-- https://github.com/gmh5225/BE-BEClient
-- https://github.com/gmh5225/Battleye-Shellcode-Dumper [BEClient2.dll Dumper]
-- https://github.com/gmh5225/be-shellcode-tester [BattlEye shellcodes tester]
+- https://github.com/dllcrt0/battleye-decryption
+- https://github.com/dllcrt0/bedaisy-reversal
+- https://github.com/dllcrt0/battleye-shellcode
+- https://github.com/Compiled-Code/be-injector [Attack COW]
+- https://github.com/Aki2k/BEDaisy
+- https://github.com/Luohuayu/BadEye
+- https://github.com/zouxianyu/BlindEye [Packet Fucker]
+- https://github.com/huoji120/goodeye
+- https://github.com/LilPidgey/BEClient
+- https://github.com/lguilhermee/Battleye-Shellcode-Dumper [BEClient2.dll Dumper]
+- https://github.com/es3n1n/be-shellcode-tester [BattlEye shellcodes tester]
 
 > Explore AntiCheat System:EQU8
 - https://back.engineering/12/08/2021
 - https://github.com/kkent030315/EQU8-PoC
-- https://github.com/gmh5225/equ8_bypass
+- https://github.com/hotline1337/equ8_bypass
 
 > Explore AntiCheat System:Ricochet
 - https://github.com/weak1337/ricochet_deobfuscator
 - https://github.com/kkent030315/AurumRE
 
 > Explore AntiCheat System:RIOT
-- https://github.com/gmh5225/DecryptionDumper [Dump]
+- https://github.com/Nuxar1/DecryptionDumper [Dump]
 
 > Explore AntiCheat System:XignCode
-- https://github.com/gmh5225/XignCode-Dump
+- https://github.com/Skengdo/XignCode-Dump
 
 > Explore AntiCheat System:ACE
-- https://github.com/gmh5225/sguard_limit
+- https://github.com/H3d9/sguard_limit
 
 > Explore AntiCheat System:G-Presto
-- https://github.com/gmh5225/G-Presto-Anti-Cheat-Reverse-Engineered/blob/main/Main.cpp
+- https://github.com/ARandomPerson7/G-Presto-Anti-Cheat-Reverse-Engineered/blob/main/Main.cpp
 
 > Explore AntiCheat System:NeacSafe
 - https://github.com/gmh5225/NeacSafe-Analysis
 
 > Explore AntiCheat System:BadlionAnticheat
-- https://github.com/gmh5225/BadlionLogger
+- https://github.com/KiFilterFiberContext/BadlionLogger
 
 > Explore AntiCheat System:Byfron
 - https://byfron.tech/
@@ -915,37 +915,37 @@
 - https://gist.github.com/gmh5225/cbe40345a9400b01329e025478ffb826 [hash]
 
 > Explore AntiCheat System:NGS
-- https://github.com/gmh5225/NGS-NexonGameSecurity-bypass
+- https://github.com/st4ckh0und/NexonGameSecurity-bypass
 
 > Explore AntiCheat System:FACEIT
-- https://github.com/gmh5225/cve-faceit-EC_PRO-LAN
+- https://github.com/ekknod/EC_PRO-LAN
 
 > Game:MapleStory
 - https://forum.ragezone.com/f922/getting-packet-structures-opcodes-using-792436 [Packet]
 - https://github.com/Bratah123/SpiritIDAPlugin [IDA-Plugin]
 - https://github.com/icelemon1314/mapleLemon [Private Server-CMS-027]
-- https://github.com/gmh5225/MS-079-Server-MapleStory [Private Server-CMS-079]
+- https://github.com/ellermister/MapleStory [Private Server-CMS-079]
 - https://forum.ragezone.com/f428/maplestory-private-server-v83-741739 [Private Server-GMS-083]
 - https://github.com/Z41N/v83MaplestoryCPP [Private Server-GMS-083 C++]
 - https://github.com/Fraysa/Destiny [Private Server-GMS-083 C#]
 - https://github.com/Bratah123/ElectronMS [Private Server-KMS-316]
 - https://github.com/Bratah123/BattleAnalysis176 [Battle Analysis]
-- https://github.com/gmh5225/MapleStory-BuildFramework [AntiCheat]
-- https://github.com/gmh5225/Maplestory-V179-Cheat-Engine [V179 CT]
-- https://github.com/gmh5225/MapleStory-HeavenClient [Heaven Client]
-- https://github.com/gmh5225/TWMS-Hacking-Data [TMS CT]
-- https://github.com/gmh5225/MapleStory-MSDoggy [TMS Old Hack]
-- https://github.com/gmh5225/MapleStory-MSB [GMS Old Hack 128-140]
-- https://github.com/gmh5225/MapleStory-MSC [GMS Bot]
-- https://github.com/gmh5225/MapleStory-Rebirth [Private Server-GMS-095 C#]
-- https://github.com/gmh5225/MapleStory-mnwvs196 [Private Server-TMS-196]
-- https://github.com/gmh5225/MapleStory-MapleResearch [GMS-095 Client Analysis]
-- https://github.com/gmh5225/Maplestory-RustMS [Private Server-Rust]
-- https://github.com/gmh5225/Maplestory-WzComparerR2 [Maplestory online Extractor]
-- [Generate machine learning object detection samples from Maplestory in different formats](https://github.com/gmh5225/MapleStory-DetectionSampleGenerator)
+- https://github.com/johnsonjason/MapleStoryBuildFramework [AntiCheat]
+- https://github.com/Noosh404/Maplestory-V179-Cheat-Engine [V179 CT]
+- https://github.com/HeavenClient/HeavenClient [Heaven Client]
+- https://github.com/Inndy/TWMS-Hacking-Data [TMS CT]
+- https://github.com/Inndy/MSDoggy [TMS Old Hack]
+- https://github.com/PrinceFroggy/MSB [GMS Old Hack 128-140]
+- https://github.com/PrinceFroggy/MSC [GMS Bot]
+- https://github.com/v3921358/Rebirth [Private Server-GMS-095 C#]
+- https://github.com/MapleStoryGameHack/mnwvs196 [Private Server-TMS-196]
+- https://github.com/Maxcloud/MapleResearch [GMS-095 Client Analysis]
+- https://github.com/neeerp/RustMS [Private Server-Rust]
+- https://github.com/Kagamia/WzComparerR2 [Maplestory online Extractor]
+- [Generate machine learning object detection samples from Maplestory in different formats](https://github.com/charlescao460/MapleStoryDetectionSampleGenerator)
 
 > Game:Minecraft
-- [A minecraft server backend written in c++](https://github.com/gmh5225/minecpp)
+- [A minecraft server backend written in c++](https://github.com/mmbednarek/minecpp)
 
 > Game:Sword With Sauce
 - https://github.com/1hAck-0/UE4-Cheat-Source-Code
@@ -955,73 +955,73 @@
 
 > Game:Fall Guys
 - https://github.com/shalzuth/FallGuysSharp
-- https://github.com/gmh5225/FallGuys
+- https://github.com/ioncodes/FallGuys
 
 > Game:Remnant
 - https://github.com/shalzuth/RemnantESP
 
 > Game:LostArk
 - https://github.com/shalzuth/LostArkLogger
-- https://github.com/gmh5225/LOST-ARK-SDK
+- https://github.com/realrespecter/LOST-ARK-SDK
 
 > Game:Battlerite
 - https://github.com/shalzuth/BattleriteBot
 
 > Game:CrossFire
-- https://github.com/gmh5225/CF-titancf
+- https://github.com/crvvdev/titancf
 
 > Game:TGame
-- https://github.com/gmh5225/nz-d3d-Perspective [D3D9]
+- https://github.com/3tnet/nzPerspective [D3D9]
 
 > Game:LOL
 - https://github.com/LeagueSharp
 - https://github.com/shalzuth/LeagueSharp
 - https://github.com/shalzuth/LoLClient
-- https://github.com/gmh5225/L-Assemblies
-- https://github.com/gmh5225/LeagueSharp.Loader
+- https://github.com/RyukOP/L-Assemblies
+- https://github.com/korllan/LeagueSharp.Loader
 - https://github.com/R3nzTheCodeGOD/R3nzSkin [Skin]
-- https://github.com/gmh5225/LOL-LeagueSkinChanger [Skin]
-- https://github.com/gmh5225/hh-lol-prophet
-- https://github.com/gmh5225/DecryptionDumper [Dump]
+- https://github.com/B3akers/LeagueSkinChanger [Skin]
+- https://github.com/real-web-world/hh-lol-prophet
+- https://github.com/Nuxar1/DecryptionDumper [Dump]
 - https://github.com/LeaguePrank/LeagueTeamBoost
-- https://github.com/gmh5225/League-of-Legends-Bot-Orbwalker-Lasthit-Laneclear-Skin-Changer-Vanguard-Spoofer
+- https://github.com/newworld7777/League-of-Legends-Bot-Orbwalker-Lasthit-Laneclear-Skin-Changer-Vanguard-Spoofer
 - https://github.com/LeagueSandbox
-- https://github.com/gmh5225/lol-unpackman
-- [A bran-new League of Legends assistant software, a replacement for WeGame](https://github.com/gmh5225/LOL-frank)
-- https://github.com/gmh5225/LOL-LViewLoL [Python based scripting platform]
-- https://github.com/gmh5225/LOL-KBotExt [LCU]
-- https://github.com/gmh5225/LOL-ayaya-league-external [Nodejs based scripting platform]
-- https://github.com/gmh5225/LOL-TFT-OCR-BOT [TFT]
+- https://github.com/MythicManiac/lol-unpackman
+- [A bran-new League of Legends assistant software, a replacement for WeGame](https://github.com/Java-S12138/frank)
+- https://github.com/orkido/LViewLoL [Python based scripting platform]
+- https://github.com/KebsCS/KBotExt [LCU]
+- https://github.com/botkalista/ayaya-league-external [Nodejs based scripting platform]
+- https://github.com/jfd02/TFT-OCR-BOT [TFT]
 
 > Game:NARAKA
 - https://www.unknowncheats.me/forum/other-fps-games/490052-naraka-bladepoint-reversal-structs-offsets.html
-- https://github.com/gmh5225/DummyDlls_NARAKA_1_9_21 [Dump]
+- https://github.com/xkp95175333/DummyDlls_NARAKA_1_9_21 [Dump]
 
 > Game:Thetan
-- https://github.com/gmh5225/Thetan_ArenaSDK
+- https://github.com/xkp95175333/Thetan_ArenaSDK
 
 > Game:Dota2
 - https://github.com/skrixx68/Dota2-Overlay-2.0
 - https://github.com/skrixx68/Dota2-Overlay-OffsetUpdater
 
 > Game:WOW
-- https://github.com/gmh5225/wow-IAT-fix
-- https://github.com/gmh5225/wow-dumpwow
-- https://github.com/gmh5225/wow-x14.08-coverstory-blizzard
+- https://github.com/helloobaby/wow-IAT-fix
+- https://github.com/namreeb/dumpwow
+- https://github.com/xakepru/x14.08-coverstory-blizzard
 
 > Game:CS1.6
-- https://github.com/gmh5225/CS16-hpp-hack
+- https://github.com/k4ne1337/hpp-hack
 
 > Game:CSGO
-- https://github.com/gmh5225/CSGO-master-guide [Guide]
+- https://github.com/csgohacks/master-guide [Guide]
 - https://github.com/frk1/hazedumper [Offset]
 - https://github.com/KittenPopo/csgo-offsets [Offset]
 - https://github.com/ofDataa/offsets [Offset]
-- https://github.com/gmh5225/csgo-auto_dumper [Auto Dump]
+- https://github.com/Akandesh/csgo_auto_dumper [Auto Dump]
 - https://github.com/dretax/GarHal_CSGO
 - https://github.com/danielkrupinski/Osiris
 - https://github.com/danielkrupinski/GOESP [Cross-platform]
-- https://github.com/gmh5225/CSGO-Anubis
+- https://github.com/danielkrupinski/Anubis
 - https://github.com/s3pt3mb3r/Dainsleif
 - https://github.com/lagcomp/csgo_sdk
 - https://github.com/ekknod/csf_w [Win SDK]
@@ -1033,24 +1033,24 @@
 - https://github.com/HeathHowren/CSGO-Cheats
 - https://github.com/Kruziikrel1/CSGO-FindMDL [Model Changer]
 - https://github.com/ekknod/nv_v2 [Sound ESP]
-- https://github.com/gmh5225/CSGO-Improved-CSGO_Simple
-- https://github.com/gmh5225/CSGO-SpyExternal1337hax [External]
-- https://github.com/gmh5225/CSGO-Seaside [Internal]
-- https://github.com/gmh5225/CSGO-Lumina-Cheat [Internal]
-- https://github.com/gmh5225/CSGO-norsefire [Driver + Mouse Emulation]
-- https://github.com/gmh5225/CSGO-boltobserv [Radar]
-- https://github.com/gmh5225/CSGO-external_ahk_hack [External]
-- https://github.com/gmh5225/CSGO-P2C-Dumper [Dump]
-- https://github.com/gmh5225/CSGO-2k17-club
-- https://github.com/gmh5225/csgo-xenforo-loader
-- https://github.com/gmh5225/CSGO-ezfrags
-- https://github.com/gmh5225/CSGO-MAIN-INTERNAL
-- https://github.com/gmh5225/csgo-digital-sdk
-- https://github.com/gmh5225/CSGO_BacktrackPatch [Backtrack Patch]
-- https://github.com/gmh5225/CSGO-NullBase [External]
-- https://github.com/gmh5225/CSGO-AqHax-CSGO
-- https://github.com/gmh5225/csgo-dma-overlay [DMA]
-- https://github.com/gmh5225/csgo-external-cheat
+- https://github.com/DerGrosse-prog/Improved-CSGO_Simple
+- https://github.com/0TheSpy/SpyExternal1337hax [External]
+- https://github.com/0TheSpy/Seaside [Internal]
+- https://github.com/whereisr0da/Lumina-Cheat [Internal]
+- https://github.com/nbqofficial/norsefire [Driver + Mouse Emulation]
+- https://github.com/boltgolt/boltobserv [Radar]
+- https://github.com/worse-666/csgo_external_ahk_hack [External]
+- https://github.com/ch4ncellor/CSGO-P2C-Dumper [Dump]
+- https://github.com/Akatsyk/2k17-club
+- https://github.com/flowxrc/csgo-xenforo-loader
+- https://github.com/ALittlePatate/ezfrags
+- https://github.com/Neaxic/CSGO-MAIN-INTERNAL
+- https://github.com/W1lliam1337/digital-sdk
+- https://github.com/sneakyevilSK/CSGO_BacktrackPatch [Backtrack Patch]
+- https://github.com/NullTerminatorr/NullBase [External]
+- https://github.com/krxdev-kaan/AqHax-CSGO
+- https://github.com/slack69/csgo-dma-overlay [DMA]
+- https://github.com/rrpvm/csgo-external-cheat
 
 > Game:Valorant
 - https://github.com/apekros/valorant_offsets [Offset]
@@ -1058,47 +1058,47 @@
 - https://github.com/ofDataa/offsets [Offset]
 - https://github.com/pebu1337/valorant-externals [Offset]
 - https://github.com/Pinguu-dev/PINGUU-VAL
-- https://github.com/gmh5225/valorant-gui-imgui-remake [GUI]
-- https://github.com/gmh5225/valorant-internal
-- https://github.com/gmh5225/ValoAutoDecryption [Decryption]
+- https://github.com/skechtew/valorant-gui-imgui-remake [GUI]
+- https://github.com/reahly/valorant-internal
+- https://github.com/Chase1803/ValorantKeyAndState [Decryption]
 - https://github.com/gmh5225/Zenti-Valorant-Cheat-Hack-Internal-Spoofer-Driver-Injector-Protector-Auth
 - https://github.com/gmh5225/Valorant-Hack-Esp-Aimbot-Driver-Injector-With-Spoofer-Temporary
-- https://github.com/gmh5225/valorant-dumper [Dump]
-- https://github.com/gmh5225/Valorant-Dumper-Tool [Dump]
-- https://github.com/gmh5225/Valorant-Esp-Aimbot-Hack
-- https://github.com/gmh5225/Valorant-external-UE4-c- [External]
-- https://github.com/gmh5225/Valorant-Cheat-External [External]
-- https://github.com/gmh5225/Valorant-Cheat
-- [Iterate And Decrypt FNamePool->Entries On Valorant](https://github.com/gmh5225/VALORANT-FNamePool)
-- https://github.com/gmh5225/Valorant-External
-- https://github.com/gmh5225/Valorant-UCMiraka-ValorantExternal [NtUserGetPointerProprietaryId]
-- https://github.com/gmh5225/Valorant-CheatExternal
+- https://github.com/xehn1337/valorant-dumper [Dump]
+- https://github.com/Chase1803/Valorant-Dumper-Tool [Dump]
+- https://github.com/kerememrerer/Eduty-Valorant-Esp-Aimbot-Hack
+- https://github.com/frankelitoc/UE4-c- [External]
+- https://github.com/AryuInka/Valorant-Cheat-External [External]
+- https://github.com/xEnething/Valorant-Cheat
+- [Iterate And Decrypt FNamePool->Entries On Valorant](https://github.com/percpopper/VALORANT-FNamePool)
+- https://github.com/SarnaxLii/Valorant-External
+- https://github.com/Chase1803/UCMiraka-ValorantExternal [NtUserGetPointerProprietaryId]
+- https://github.com/Chase1803/ValorantCheatExternal
 
 > Game:VEILED EXPERTS
-- https://github.com/gmh5225/VEILED-EXPERTS-SDK
-- https://github.com/gmh5225/ProjectD-Win64-Shipping
-- https://github.com/gmh5225/VeiledExpertsSDK
+- https://github.com/EBalloon/VEILED-EXPERTS-SDK
+- https://github.com/LagradOst/ProjectD-Win64-Shipping
+- https://github.com/Da3kL3o/VeiledExpertsSDK
 
 > Game:COD1
-- https://github.com/gmh5225/CoD_Hacks
+- https://github.com/attilathedud/CoD_Hacks
 
 > Game:COD Warzone
-- https://github.com/gmh5225/COD-Warzone-MW-HACK-ESP-AIMBOT
-- https://github.com/gmh5225/COD-Warzone-mwclap
+- https://github.com/YMY1666527646/Call-of-Duty-Warzone-MW-HACK-ESP-AIMBOT
+- https://github.com/serjam/mwclap
 - https://github.com/NMan1/external-warzone-cheat
 - https://github.com/NMan1/warzone-internal
-- https://github.com/gmh5225/Call-Of-Duty-Warzone-Hack-Esp-Slient-Aimbot-Internal-Unlock-ALL
-- https://github.com/gmh5225/Call-Of-Duty-Vanguard-Hack-Esp-AImbot-Unlock-All
+- https://github.com/KoobiR76/Call-Of-Duty-Warzone-Hack-Esp-Slient-Aimbot-Internal-Unlock-ALL
+- https://github.com/KoobiR76/Call-Of-Duty-Vanguard-Hack-Esp-AImbot-Unlock-All
 
 > Game:Battlefield 1
-- https://github.com/gmh5225/BF1-ESP-AND-AIMBOT
-- https://github.com/gmh5225/BattleField-1-Internal
+- https://github.com/Zakaria-Master/BF1-ESP-AND-AIMBOT
+- https://github.com/younasiqw/BattleField-1-Internal
 
 > Game:Battlefield 4
-- https://github.com/gmh5225/BF4-Internal-overlay
+- https://github.com/Zakaria-Master/BF4-Internal-overlay
 
 > Game:Battlefield 2042
-- https://github.com/gmh5225/battlefield-2042-internal-sdk
+- https://github.com/Skengdo/battlefield-2042-internal-sdk
 
 > Game:Apex Legends
 - https://github.com/dhanax26/Apex-Legends-Offset-Dumper [Offset]
@@ -1109,18 +1109,18 @@
 - https://github.com/rakuza2/SIMPLE-AIMBOT-GLOW-APEX
 - https://github.com/TheCruZ/Direct-EFI-Apex-Cheat
 - https://github.com/Astronaut00/apex-external
-- https://github.com/gmh5225/Valorant-Phoenix-Cheat
+- https://github.com/YMY1666527646/Phoenix-Valorant-Cheat
 - https://github.com/CasualX/apexbot
-- https://github.com/gmh5225/APEX-ESP_AIMBOT
-- https://github.com/gmh5225/Apex-Legends_Driver_Cheat
+- https://github.com/loplopuu23/APEX_ESP_AIMBOT
+- https://github.com/TheCruZ/Apex_Legends_Driver_Cheat
 - https://github.com/Keyzp1337/Fortnite
-- https://github.com/gmh5225/Apex-AI-NuremX [AI]
-- https://github.com/gmh5225/apex_full_cheat
+- https://github.com/Zurek0x/NuremX [AI]
+- https://github.com/hadevn/apex_full_cheat
 - https://github.com/gmh5225/Apex-ApexCheeseTest
-- https://github.com/gmh5225/Apex-Legends-Esp
-- https://github.com/gmh5225/Apex-ApexCheat
-- https://github.com/gmh5225/Apex_ESP_Old_Project
-- https://github.com/gmh5225/apex-cheating
+- https://github.com/RavenOfTime/Apex-Legends-Esp
+- https://github.com/DeplayBack/ApexCheat
+- https://github.com/Zakaria-Master/Apex_ESP_Old_Project
+- https://github.com/cheatingwitdacode/apex-cheating
 
 > Game:Fortnite
 - https://github.com/ofDataa/offsets [Offset]
@@ -1138,152 +1138,152 @@
 - https://github.com/Makk5/FortConsole
 - https://github.com/skidseal/FortniteLeak5
 - https://github.com/Zetolac/FortniteExternalW2S
-- https://github.com/gmh5225/Fortnite-Internal-Cheat-Fixed-and-Updated
-- https://github.com/gmh5225/Fortnite-EFI-External [EFI]
-- https://github.com/gmh5225/Fortnite-External-Cheat-WinSense-Leak
-- https://github.com/gmh5225/fortnite-cheat-source-internal
-- https://github.com/gmh5225/Fortnite-Hack-Esp-Exploits-With-Menu
-- https://github.com/gmh5225/Fortnite-nigusFN
-- https://github.com/gmh5225/Fortnite-Source-External-EAC-BE-undetected
-- https://github.com/gmh5225/Fortnite-GodFather-Cheat-Cracked
-- https://github.com/gmh5225/Fortnite-FortGay
-- https://github.com/gmh5225/Fortnite
-- https://github.com/gmh5225/Fortnite-Basic-Cheat-Source-Internal
-- https://github.com/gmh5225/Fortnite-UD-External
-- https://github.com/gmh5225/Fortnite-Gloomy.cc
-- https://github.com/gmh5225/Fortnite-Esp-Aimbot-Exploits-Hwid-Spoofer-Cleaner-Hack-Cheat
-- https://github.com/gmh5225/Fortnite-Cheat-LEAK
-- https://github.com/gmh5225/Fortnite-Fltokens-and-offsets
-- https://github.com/gmh5225/VOLTO-EXTERNAL-SPOWAR-UD-EAC-BE-FORTNITE-EXTERNAL-CHEAT
+- https://github.com/Kiaoee/Fortnite-Internal-Cheat-Fixed-and-Updated
+- https://github.com/Kiaoee/Fortnite-EFI-External [EFI]
+- https://github.com/Giteob/Fortnite-External-Cheat-WinSense-Leak
+- https://github.com/jooola00/fortnite-cheat-source-internal
+- https://github.com/YMY1666527646/Fortnite-Hack-Esp-Exploits-With-Menu
+- https://github.com/YMY1666527646/nigusFN
+- https://github.com/Sheeedsh78/Cheto-Fortnite-Source-External-EAC-BE-undetected
+- https://github.com/CheaterRehab/GodFather-Fortnite-Cheat-Cracked
+- https://github.com/newworld7777/FortGay
+- https://github.com/Keyzp1337/Fortnite
+- https://github.com/vk-nom/Basic-Fortnite-Cheat-Source-Internal
+- https://github.com/PasterWolf/Fortnite-UD-External
+- https://github.com/Chase1803/Gloomy.cc-Fortnite
+- https://github.com/sanntoomirai/Fortnite-Esp-Aimbot-Exploits-Hwid-Spoofer-Cleaner-Hack-Cheat
+- https://github.com/Waihbe/Fortnite-Cheat-LEAK
+- https://github.com/zinx-YT/Fortnite-Fltokens-and-offsets
+- https://github.com/Giteob/VOLTO-EXTERNAL-SPOWAR-UD-EAC-BE-FORTNITE-EXTERNAL-CHEAT
 - https://github.com/gmh5225/Serenity.gg-FN-and-Loader
-- https://github.com/gmh5225/Fortnite-External-Cheat-Leak
-- https://github.com/gmh5225/fortnite-Spoofer [HWID]
-- https://github.com/gmh5225/ritz-amazing-fortnite-internal
-- https://github.com/gmh5225/Fortnite-External
-- https://github.com/gmh5225/Fortnite-Masterpasta-ihack-Source-Leak
-- https://github.com/gmh5225/Fortnite-Evo.cc-Source-External-Cheat
-- https://github.com/gmh5225/Fortnite-External-1
-- https://github.com/gmh5225/Apple-Lite-Fortnite-Cheat
-- https://github.com/gmh5225/Fortnite-External-Cheat-Source-Code
-- https://github.com/gmh5225/Fortnite-BattleFN-cheat-analysis
+- https://github.com/Waihbe/Fortnite-External-Cheat-Leak
+- https://github.com/AlfredIU/Spoofer [HWID]
+- https://github.com/pastor-ritz/ritz-amazing-fortnite-internal
+- https://github.com/SarnaxLii/Fortnite-External
+- https://github.com/plu1337/Fortnite-Masterpasta-ihack-Source-Leak
+- https://github.com/Giteob/Fortnite-Evo.cc-Source-External-Cheat
+- https://github.com/KeyzpOnTheFluxxx/Fortnite-External
+- https://github.com/Giteob/Apple-Lite-Fortnite-Cheat
+- https://github.com/Luksiuss/Fortnite-External-Cheat-Source-Code
+- https://github.com/0dayatday0/BattleFN-cheat-analysis
 
 > Game:Bloodhunt
-- https://github.com/gmh5225/HackExternal--bloodhunt
-- https://github.com/gmh5225/BloodHunt-v1.1
+- https://github.com/ZZZ-Monster/bloodhunt_External
+- https://github.com/PhysX1337/BloodHunt-v1.1
 
 > Game:Super People
 - https://github.com/EBalloon/Super-People-sdk
-- https://github.com/gmh5225/Super-People-Esp-Aimbot-Magic-Hack
+- https://github.com/archie2adolphe/Super-People-Esp-Aimbot-Magic-Hack
 
 > Game:Splitgate
-- https://github.com/gmh5225/Splitgate-Internal
+- https://github.com/percpopper/Splitgate-Internal
 
 > Game:PUBG
-- https://github.com/gmh5225/pubg-dumper [Dump]
+- https://github.com/owdata1/pubg-dumper [Dump]
 - https://github.com/Skengdoo/pubg-external-cheat
-- https://github.com/gmh5225/pubg-pubg_internal
-- https://github.com/gmh5225/pubg-internal
-- https://github.com/gmh5225/pubg-public
+- https://github.com/ajkhoury/pubg_internal
+- https://github.com/iCollin/pubg-internal
+- https://github.com/K-cazb/pubg-public
 - https://github.com/gmh5225/PlayerUnknown-s-Battlegrounds-Pubg-Steam-Hack-Esp-Aimbot
-- https://github.com/gmh5225/pubg-lilypublic
-- https://github.com/gmh5225/PUBG_Internal
+- https://github.com/dot1991/lilypublic
+- https://github.com/kurt2467/PUBG_Internal
 
 > Game:PUBG Lite
-- https://github.com/gmh5225/Pubg-Lite-ESP
+- https://github.com/Zakaria-Master/Pubg-Lite-ESP
 
 > Game:PUBGM
-- https://github.com/gmh5225/pubgm_sdk_and_offsets [Offset]
-- https://github.com/gmh5225/pubg_mobile_memory_hacking
+- https://github.com/Zakaria-Master/pubgm_sdk_and_offsets [Offset]
+- https://github.com/atulkunal999/pubg_mobile_memory_hacking
 - https://github.com/Mood-Coding/pubgm_shitty_source
-- https://github.com/gmh5225/Pubg-Mobile-Extermal-Esp-Aimbot-Magic-Injector-Spoofer
-- https://github.com/gmh5225/Pubg-Mobile-Esp-Aimbot-Magic-Injector-Spoofer
-- https://github.com/gmh5225/PUBGM-PUBGPatcher
-- https://github.com/gmh5225/PUBGM1.6-DeadGame
+- https://github.com/TheLoneHaxor/Pubg-Mobile-Extermal-Esp-Aimbot-Magic-Injector-Spoofer
+- https://github.com/sanntoomirai/Pubg-Mobile-Esp-Aimbot-Magic-Injector-Spoofer
+- https://github.com/kp7742/PUBGPatcher
+- https://github.com/Zakaria-Master/PUBGM1.6-DeadGame
 
 
 > Game:EFT
-- https://github.com/gmh5225/EFT-StreamedCheat
-- https://github.com/gmh5225/EFT-Escape-From-Tarkov-External-Esp-Aimbot-eft-Hack-Cheat-Injector-Spoofer
-- https://github.com/gmh5225/EFT-pKernelInterface-EFT
-- https://github.com/gmh5225/EFT-EscapeFromTarkov-Trainer
-- https://github.com/gmh5225/eft-tiny_eft
-- https://github.com/gmh5225/eft-Nathans-Tarkov-Radar-Public [Vmread + Radar]
-- https://github.com/gmh5225/eft-external
-- https://github.com/gmh5225/eft
-- https://github.com/gmh5225/eft-internal
-- https://github.com/gmh5225/EFT-Veil-EFT
+- https://github.com/fcancelog/EftStreamedCheat
+- https://github.com/sanntoomirai/Escape-From-Tarkov-External-Esp-Aimbot-eft-Hack-Cheat-Injector-Spoofer
+- https://github.com/Nou4r/pKernelInterface-EFT
+- https://github.com/sailro/EscapeFromTarkov-Trainer
+- https://github.com/vmwrite/tiny_eft
+- https://github.com/CplNathan/Nathans-Tarkov-Radar-Public [Vmread + Radar]
+- https://github.com/frankie-11/eft-external
+- https://github.com/Splitx12/eft
+- https://github.com/TupleDev/eft-internal
+- https://github.com/TupleDev/Veil-EFT
 
 > Game:R6
 - https://github.com/NMan1/Rainbow-Six-Cheat
 - https://github.com/NMan1/OverflowR6V2
 - https://github.com/NMan1/Internal-Rainbow-Six-Cheat-V3
-- https://github.com/gmh5225/Rainbow-epic-r6-v9
-- https://github.com/gmh5225/Rainbow-R6Updater
-- https://github.com/gmh5225/Rainbow-R6Table_Internal
-- https://github.com/gmh5225/rainbow-r6-internal
-- https://github.com/gmh5225/R6-External-R6S-Cheat
+- https://github.com/beans42/epic-r6-v9
+- https://github.com/Kix48/R6Updater
+- https://github.com/hooksteroid/R6Table_Internal
+- https://github.com/JGonz1337/r6-internal
+- https://github.com/SurgeGotTappedAgain/External-R6S-Cheat
 
 > Game:Overwatch 
 - https://github.com/blackhades00/PareidoliaTriggerbot [Triggerbot]
 - https://github.com/ReynmenRcs/Overwatch-External-Esp-Aimbot-Hack-Cheat
-- https://github.com/gmh5225/Overwatch-1-cheat-source
+- https://github.com/OSNSON/Overwatch-1-cheat-source-.
 
 > Game:Paladins
 - https://github.com/gmh5225/Paladins-Internal-Esp-Aimbot-Hack-Cheat-Hack
 
 > Game:DayZ
-- https://github.com/gmh5225/DayZ-External-Esp-Aimbot-Spoofer-Hack-Cheat
-- https://github.com/gmh5225/DayZ-DayZzz
+- https://github.com/sanntoomirai/DayZ-External-Esp-Aimbot-Spoofer-Hack-Cheat
+- https://github.com/zhitkur/DayZzz
 
 > Game:Squad
-- https://github.com/gmh5225/Squad-External-Esp-Aimbot-Cheat-Hack
+- https://github.com/TheLoneHaxor/Squad-External-Esp-Aimbot-Cheat-Hack
 
 > Game:Rust
-- https://github.com/gmh5225/rust-auto-dumper [Auto Dump]
+- https://github.com/Akandesh/rust-auto-dumper [Auto Dump]
 - https://github.com/NMan1/OverflowRust
-- https://github.com/gmh5225/simple-rust-hack
-- https://github.com/gmh5225/rust-internal
+- https://github.com/ReFo0/simple-rust-hack
+- https://github.com/Facepunch-bot/rust-internal
 - https://github.com/gmh5225/Rust-Internal-Esp-Aimbot-Spoofer-Hack-Cheat-Injector-Driver
 - https://github.com/gmh5225/Rust-External-Esp-Aimbot-Spoofer-Hack-Cheat-Injector-Driver
-- https://github.com/gmh5225/Rust-External
-- https://github.com/gmh5225/Rico-Cheat-rust-external
-- https://github.com/gmh5225/rust-a-pasted-rust-script
-- https://github.com/gmh5225/Rust-External-Cheat
-- https://github.com/gmh5225/rust-Kors_lol [Internal]
-- https://github.com/gmh5225/Rust-Internal-1 [Internal]
-- https://github.com/gmh5225/Rust-CRC32
-- https://github.com/gmh5225/Rust-Cheat-External
-- https://github.com/gmh5225/rust-Simple-Rust-Base
-- https://github.com/gmh5225/rust-internal-sapphire
-- https://github.com/gmh5225/Rust-Cheat-External-main
+- https://github.com/Facepunch-bot/Rust-External
+- https://github.com/Facepunch-bot/Rico-Cheat-rust-external
+- https://github.com/spyder1g/a-pasted-rust-script
+- https://github.com/LordAbbot/Rust-External-Cheat
+- https://github.com/ZentifyZ/Kors_lol [Internal]
+- https://github.com/Allerek/Rust-Internal [Internal]
+- https://github.com/ZentifyZ/CRC32
+- https://github.com/SteepCheat/Rust-Cheat-External
+- https://github.com/krispybyte/Simple-Rust-Base
+- https://github.com/vmwrite/sapphire
+- https://github.com/Disline1337/Rust-Cheat-External-main
 
 > Game:Arma3
-- https://github.com/gmh5225/arma3-external-variable-manager
-- https://github.com/gmh5225/arma3-3den-Enhanced [Mod Editor]
+- https://github.com/Skengdo/arma3-external-variable-manager
+- https://github.com/R3voA3/3den-Enhanced [Mod Editor]
 
 > Game:AVA
-- https://github.com/gmh5225/AVA-Hack
+- https://github.com/boylin0/AVA-Hack
 
 > Game:Mordhau
-- https://github.com/gmh5225/mordhau-simple-auto-block-cheat
+- https://github.com/Skengdo/mordhau-simple-auto-block-cheat
 
 > Game:Smite [UE3]
-- https://github.com/gmh5225/Smite-ESPAimbot 
+- https://github.com/JackBro/SmiteESPAimbot 
 
 > Game:Genshin Impact
 - https://github.com/khang06/mhynot2
-- https://github.com/gmh5225/genshinjumpfixer2 [Decode CFG]
-- https://github.com/gmh5225/genshin-cheat
-- https://github.com/gmh5225/Grasscutter [Private Server]
-- https://github.com/gmh5225/Genshin-Akebi-GC [Cheat]
+- https://github.com/khang06/genshinjumpfixer2 [Decode CFG]
+- https://github.com/GoChanZ/genshin-cheat
+- https://github.com/Grasscutters/Grasscutter [Private Server]
+- https://github.com/Akebi-Group/Akebi-GC [Cheat]
 - https://github.com/Razmoth/GenshinStudio [Asset]
 
 > Game:Honkai Impact
-- https://github.com/gmh5225/BH3-BetterHI3Launcher
+- https://github.com/BuIlDaLiBlE/BetterHI3Launcher
 
 > Game:EldenRing
 - https://github.com/techiew/EldenRingMods [Mod]
-- https://github.com/gmh5225/EldenRing-Launcher [Launcher]
+- https://github.com/v-maxson/EldenRingLauncher [Launcher]
 
 > Game:Dark Souls
 - https://github.com/igromanru/Dark-Souls-III-Cheat-Engine-Guide
@@ -1291,43 +1291,43 @@
 > Game:GTA5
 - https://github.com/Luksiuss/GTA-5-SIGS-1.59 [Offset]
 - [About
-Adds drag- to- resize functionality to the main GTA V window](https://github.com/gmh5225/GTAV_DragResize)
+Adds drag- to- resize functionality to the main GTA V window](https://github.com/CamxxCore/GTAV_DragResize)
 
 > Game:Geometry Dash
-- https://github.com/gmh5225/gd-internal
+- https://github.com/reservedcloud/gd-internal
 
 > Game:8ball pool
 - https://github.com/gmh5225/Alaa-8ball-pool-source-exposed
 
 > Game:Wizard101
-- https://github.com/gmh5225/wizard101-spoofer [HWID]
+- https://github.com/AmJayden/wizard101-spoofer [HWID]
 
 > Game:QQTang
-- https://github.com/gmh5225/QQTangCheatEngine
+- https://github.com/blackmaple/QQTangCheatEngine
 
 > Game:Chess
-- https://github.com/gmh5225/lc0 [Chess Engine]
-- https://github.com/gmh5225/chess-Stockfish [Chess Engine]
+- https://github.com/LeelaChessZero/lc0 [Chess Engine]
+- https://github.com/official-stockfish/Stockfish [Chess Engine]
 
 > Game:BLOCKPOST
-- https://github.com/gmh5225/BLOCKPOST-Cheat
+- https://github.com/xo1337/BLOCKPOST-Cheat
 
 > Game:Witch It
-- https://github.com/gmh5225/CheatIt
+- https://github.com/guttir14/CheatIt
 
 > Game:RO
-- https://github.com/gmh5225/RO-rAthenaCN
+- https://github.com/rAthenaCN/rAthenaCN
 
 > Game:PokemonGo
-- https://github.com/gmh5225/PokemonGoDumper
+- https://github.com/Jumboperson/PokemonGoDumper
 
 > Game:L4D2
-- https://github.com/gmh5225/L4D2-Cheat [Linux]
+- https://github.com/Fox-Cult/L4D2-Cheat [Linux]
 
 ## Anti Cheat
 > Guide
 - https://technology.riotgames.com/news/riots-approach-anti-cheat
-- https://github.com/gmh5225/AntiCheat-WeirdAntiCheatIdeas
+- https://github.com/87andrewh/WeirdAntiCheatIdeas
 - https://github.com/gmh5225/AntiCheat-chrysalis
 - https://www.unknowncheats.me/forum/anti-cheat-bypass/481731-tutorial-ring3-anticheat-project.html
 - https://github.com/dhondta/awesome-executable-packing [Executable File Packing]
@@ -1337,126 +1337,126 @@ Adds drag- to- resize functionality to the main GTA V window](https://github.com
 - https://github.com/niemand-sec/AntiCheat-Testing-Framework
 - https://github.com/stuxnet147/Known-Driver-Mappers [Known Driver Mappers]
 - https://github.com/DanielRTeixeira/injectAllTheThings [Injection Testing]
-- https://github.com/gmh5225/DLL-inject-Injectors [Injection Testing]
+- https://github.com/zoand/Injectors [Injection Testing]
 - https://github.com/guided-hacking/GuidedHacking-Injector [Injection Testing]
-- https://github.com/gmh5225/rust-dll-crab [Injection Testing]
+- https://github.com/aiocat/dll-crab [Injection Testing]
 - https://github.com/odzhan/injection [Injection Testing]
-- https://github.com/gmh5225/Driver-kinject [Injection Testing]
-- https://github.com/gmh5225/ThreadJect [Injection Testing]
-- https://github.com/gmh5225/inject-ThreadHijackingInjector [Injection Testing]
-- https://github.com/gmh5225/simple-SetWindowsHookExW-injector [Injection Testing:SetWindowsHookExW]
-- https://github.com/gmh5225/Inject-Jektor [Injection/Shellcode Testing]
-- https://github.com/gmh5225/face-injector-v2 [Injection/ Testing]
+- https://github.com/w1u0u1/kinject [Injection Testing]
+- https://github.com/D4stiny/ThreadJect [Injection Testing]
+- https://github.com/NullTerminatorr/ThreadHijackingInjector [Injection Testing]
+- https://github.com/Skengdo/simple-SetWindowsHookExW-injector [Injection Testing:SetWindowsHookExW]
+- https://github.com/FULLSHADE/Jektor [Injection/Shellcode Testing]
+- https://github.com/KANKOSHEV/face-injector-v2 [Injection/ Testing]
 - https://github.com/notscimmy/libelevate [Elevating Handle]
-- https://github.com/gmh5225/NoBastian_v2 [Elevating Handle By LSASS]
-- https://github.com/gmh5225/launcher-abuser [Elevating Handle]
-- https://github.com/gmh5225/LSASS-Usermode-Bypass [Elevating Handle By LSASS]
+- https://github.com/ZoondEngine/NoBastian_v2 [Elevating Handle By LSASS]
+- https://github.com/Ricardonacif/launcher-abuser [Elevating Handle]
+- https://github.com/ContionMig/LSASS-Usermode-Bypass [Elevating Handle By LSASS]
 - https://github.com/Mattiwatti/EfiGuard [PG Testing]
 - https://github.com/9176324/Shark [PG Testing]
 - https://github.com/gmh5225/HideDriverTesting [Hide Driver Testing]
-- https://github.com/gmh5225/HideDriver-flink-blink [Hide Driver Testing]
-- https://github.com/gmh5225/HideDriver-MiProcessLoaderEntry [Hide Driver Testing]
-- https://github.com/gmh5225/TraceCleaner [Hide Driver Testing]
-- https://github.com/gmh5225/disable-threat-tracing [ETW Testing]
+- https://github.com/nbqofficial/HideDriver [Hide Driver Testing]
+- https://github.com/ExpLife0011/HideDriver [Hide Driver Testing]
+- https://github.com/BadPlayer555/TraceCleaner [Hide Driver Testing]
+- https://github.com/muturikaranja/disable-threat-tracing [ETW Testing]
 - https://github.com/daswareinfach/Battleye-VAC-EAC-Kernel-Bypass [FsFilter Testing]
-- https://github.com/gmh5225/Injection-MMFCodeInjection [User APC + File Mapping Testing]
-- https://github.com/gmh5225/AntiDbg-TtdAntiDebugging [Debug Testing]
-- https://github.com/gmh5225/cheat-attack-thread-slemu [Hearbeat Testing]
-- https://github.com/gmh5225/MmCopyVirtualMemory-cheat-driver [MmCopyVirtualMemory Testing]
-- https://github.com/gmh5225/vt-debuuger [Hacked Hypervisor Testing]
-- https://github.com/gmh5225/vt-debuger [Hacked Hypervisor Testing]
+- https://github.com/aahmad097/MMFCodeInjection [User APC + File Mapping Testing]
+- https://github.com/liors619/TtdAntiDebugging [Debug Testing]
+- https://github.com/TupleDev/slemu [Hearbeat Testing]
+- https://github.com/nkga/cheat-driver [MmCopyVirtualMemory Testing]
+- https://github.com/zxd1994/vt-debuuger [Hacked Hypervisor Testing]
+- https://github.com/3526779568/vt-debuger [Hacked Hypervisor Testing]
 
 > Anti Debugging
 - https://github.com/LordNoteworthy/al-khaser
-- https://github.com/gmh5225/ScyllaHideDetector2 
+- https://github.com/samshine/ScyllaHideDetector2 
 - https://github.com/Ahora57/MAJESTY-technologies
 - https://github.com/AdvDebug/AntiCrack-DotNet [CSharp]
 - https://github.com/weak1337/CEDetector [CE]
 - https://github.com/gmh5225/Detection-CheatEngine [CE]
-- https://github.com/gmh5225/AntiDbg-AmogusPlugin
-- https://github.com/gmh5225/Android-AntiDebugandMemoryDump [Android]
-- [Sample anti-debug with detect ScyllaHide/HyperHide and TitanHide](https://github.com/gmh5225/antidbg-Baka)
-- [Linux anti-debugging techniques](https://github.com/gmh5225/linux-antidbg-adbg)
-- https://github.com/gmh5225/AntiDBG
-- https://github.com/gmh5225/linux-anti-debug-LADD [Linux]
+- https://github.com/Ahora57/AmogusPlugin
+- https://github.com/polaryy/AntiDebugandMemoryDump [Android]
+- [Sample anti-debug with detect ScyllaHide/HyperHide and TitanHide](https://github.com/Ahora57/Baka)
+- [Linux anti-debugging techniques](https://github.com/hiatus/adbg)
+- https://github.com/HackOvert/AntiDBG
+- https://github.com/BarakAharoni/LADD [Linux]
 - https://github.com/gmh5225/AntiKernelDebug-POC [Windows Kernel]
-- https://github.com/gmh5225/antidbg-cpp-anti-debug
-- https://github.com/gmh5225/Anti-Debug
-- https://github.com/gmh5225/antidbg-RaceCondition
-- https://github.com/gmh5225/AntiCrack-DotNet [DotNet]
-- https://github.com/gmh5225/antidbg-umium [C++/CLI]
-- https://github.com/gmh5225/Anti-Debugger-Protector-Loader
+- https://github.com/BaumFX/cpp-anti-debug
+- https://github.com/Metick/Anti-Debug
+- https://github.com/Ahora57/RaceCondition
+- https://github.com/AdvDebug/AntiCrack-DotNet [DotNet]
+- https://github.com/hotline1337/umium [C++/CLI]
+- https://github.com/YouNeverKnow00/Anti-Debugger-Protector-Loader
 
 > Page Protection
 - https://github.com/changeofpace/Self-Remapping-Code
 - https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-addsecurememorycachecallback
 - https://github.com/weak1337/NO_ACCESS_Protection
-- https://github.com/gmh5225/page_no_access
-- https://github.com/gmh5225/PAGE_NO_ACCESS_DeepSleep
-- https://github.com/gmh5225/DeathSleep
-- https://github.com/gmh5225/PAGE_NO_ACCESS-ShellcodeFluctuation
-- https://github.com/gmh5225/veh-printf-hook [PAGE_GUARD]
-- https://github.com/gmh5225/PointerGuard-1 [PAGE_GUARD]
-- https://github.com/gmh5225/veh_hide_memory [PAGE_NOACCESS]
+- https://github.com/hotline1337/page_no_access
+- https://github.com/thefLink/DeepSleep
+- https://github.com/janoglezcampos/DeathSleep
+- https://github.com/mgeeky/ShellcodeFluctuation
+- https://github.com/Gofrettin/veh-printf-hook [PAGE_GUARD]
+- https://github.com/charliewolfe/PointerGuard [PAGE_GUARD]
+- https://github.com/ilovecsad/veh_hide_memory [PAGE_NOACCESS]
 
 > Binary Packer
 - https://github.com/dhondta/awesome-executable-packing
 - https://github.com/phra/PEzor
-- https://github.com/gmh5225/Packer-PE-Packer [X86]
-- https://github.com/gmh5225/Packer [X86]
-- https://github.com/gmh5225/pe-protector [X86]
+- https://github.com/czs108/PE-Packer [X86]
+- https://github.com/longqun/Packer [X86]
+- https://github.com/ATsahikian/pe-protector [X86]
 - https://github.com/iArtorias/debug_remover [Strip Debug Info]
-- https://github.com/gmh5225/packer-pe32-password
-- https://github.com/gmh5225/packer-Huan
-- https://github.com/gmh5225/packer-HintInject [Hint/Name Table]
-- https://github.com/gmh5225/Android-obf-Obfuscapk [Android]
-- https://github.com/gmh5225/Packer-Embuche [ELF]
-- https://github.com/gmh5225/packer-amber
-- https://github.com/gmh5225/packer-PePacker
-- https://github.com/gmh5225/Packer-wrappe [Rust]
-- https://github.com/gmh5225/packer-woody_woodpacker [ELF]
-- https://github.com/gmh5225/packer-m0dern_p4cker [ELF]
-- https://github.com/gmh5225/packer-peinjector
-- https://github.com/gmh5225/packer-AresFramework
-- https://github.com/gmh5225/packer--exe_packer
+- https://github.com/ytk2128/pe32-password
+- https://github.com/frkngksl/Huan
+- https://github.com/frkngksl/HintInject [Hint/Name Table]
+- https://github.com/ClaudiuGeorgiu/Obfuscapk [Android]
+- https://github.com/magnussen7/Embuche [ELF]
+- https://github.com/EgeBalci/amber
+- https://github.com/SamLarenN/PePacker
+- https://github.com/Systemcluster/wrappe [Rust]
+- https://github.com/vsteffen/woody_woodpacker [ELF]
+- https://github.com/n4sm/m0dern_p4cker [ELF]
+- https://github.com/JonDoNym/peinjector
+- https://github.com/craids/AresFramework
+- https://github.com/andrew9382/exe_packer
 
 > CLR Protection
-- https://github.com/gmh5225/ClrGuard
+- https://github.com/endgameinc/ClrGuard
 
 > Anti Disassembly
-- https://github.com/gmh5225/Anti-Disassembly-blackhat2012
+- https://github.com/rrbranco/blackhat2012
 
 > Sample Unpacker
 - https://github.com/hasherezade/mal_unpack_drv
-- https://github.com/gmh5225/android-unpacker [Android]
+- https://github.com/strazzere/android-unpacker [Android]
 
 > Dump Fix
-- https://github.com/gmh5225/dump-unmapper
-- https://github.com/gmh5225/Dump-DumpPE
+- https://github.com/t3ssellate/unmapper
+- https://github.com/d35ha/DumpPE
 
 > Encrypt Variable
-- https://github.com/gmh5225/encrypt-encrypted_value [C++]
-- https://github.com/gmh5225/encrypt-e3 [C++]
-- https://github.com/gmh5225/xor-float [C++]
+- https://github.com/serge-14/encrypted_value [C++]
+- https://github.com/momalab/e3 [C++]
+- https://github.com/obama-gaming/xor-float [C++]
 
 > Obfuscation Engine
 - https://github.com/mike1k/perses
 - https://github.com/jnastarot/furikuri
 - https://github.com/nickcano/RelocBonus [Attack Reloc]
-- https://github.com/gmh5225/packer-nmmp [Dex]
-- https://github.com/gmh5225/Android-dex-BlackObfuscator [Dex]
+- https://github.com/maoabc/nmmp [Dex]
+- https://github.com/CodingGay/BlackObfuscator [Dex]
 - https://github.com/d35ha/CallObfuscator [Call Obfuscation]
-- https://github.com/gmh5225/mutation-Milfuscator
-- https://github.com/gmh5225/the-poor-mans-obfuscator [elf/macho]
-- https://github.com/gmh5225/java-obf-proguard [Java]
+- https://github.com/nelfo/Milfuscator
+- https://github.com/romainthomas/the-poor-mans-obfuscator [elf/macho]
+- https://github.com/Guardsquare/proguard [Java]
 
 > Screenshot
 - https://github.com/bavulapati/DXGICaptureApplication [Capture Desktop]
 - https://github.com/Rick-laboratory/Windows-Screenshotcapture-DirectX/blob/master/main.cpp [DX9]
-- https://github.com/gmh5225/dwm-screen-shot [DWM]
-- https://github.com/gmh5225/D3D-screencapture [DX11]
-- https://github.com/gmh5225/screenshot-WindowsDesktopDuplicationSample [DXGI]
-- https://github.com/gmh5225/screenshot-GetPixel-vs-BitBlt_GetDIBits [GetPixel]
+- https://github.com/lainswork/dwm-screen-shot [DWM]
+- https://github.com/kirides/screencapture [DX11]
+- https://github.com/bmharper/WindowsDesktopDuplicationSample [DXGI]
+- https://github.com/PierreCiholas/GetPixel-vs-BitBlt_GetDIBits [GetPixel]
 
 > Game Engine Protection:Unreal
 - https://github.com/zompi2/Static-Variables-Obfuscator-UE4
@@ -1466,30 +1466,30 @@ Adds drag- to- resize functionality to the main GTA V window](https://github.com
 - https://github.com/ls9512/USecurity
 
 > Game Engine Protection:Source
-- [Source Engine serverside anti-cheat plugin. (CS:S, CS:GO, CS:P, TF2)](https://github.com/gmh5225/AntiCheat-NoCheatZ-3)
+- [Source Engine serverside anti-cheat plugin. (CS:S, CS:GO, CS:P, TF2)](https://github.com/kanekikun420/NoCheatZ-3)
 
 > Open Source Anti Cheat System
 - https://github.com/mq1n/NoMercy
-- https://github.com/gmh5225/Anticheat-BetaShield
+- https://github.com/JackBro/BetaShield
 - https://github.com/chztbby/RebirthGuard
 - https://github.com/GravitLauncher/Avanguard
 - https://github.com/Rycooop/Bloom-Anticheat
-- https://github.com/gmh5225/AntiMalware-Stresser [Anti Virus in fact but also Anti Cheat]
+- https://github.com/AvivShabtay/Stresser [Anti Virus in fact but also Anti Cheat]
 - https://github.com/danielkrupinski/VAC [Reversed VAC]
-- https://github.com/gmh5225/anti-cheat-emulator
+- https://github.com/ApexLegendsUC/anti-cheat-emulator
 - https://github.com/ch4ncellor/EAC-Reversal [Reversed EAC]
 - https://github.com/weak1337/BE-Shellcode [Reversed BE Shellcode]
 - https://github.com/codetronik/AndroidAntiCheat [Android Platform]
 - https://github.com/MrDiamond64/Scythe-AntiCheat [Minecraft]
-- https://github.com/gmh5225/AntiCheat
-- https://github.com/gmh5225/EDR-whids [EDR]
-- https://github.com/gmh5225/EDR-Raccine [EDR]
-- https://github.com/gmh5225/UltimateAntiCheat
-- https://github.com/gmh5225/Anti-Cheat-Quack
-- [Source Engine serverside anti-cheat plugin. (CS:S, CS:GO, CS:P, TF2)](https://github.com/gmh5225/AntiCheat-NoCheatZ-3)
-- [This is the Anti Cheat System for Knight Online Gamesoft vversion](https://github.com/gmh5225/AntiCheat-GamesoftACS)
-- [User-mode C++ Anti-Cheat written for German Roleplay Server GVMP.de](https://github.com/gmh5225/gvmp-anticheat)
-- [Cheat developer platform](https://github.com/gmh5225/anti-cheat-UAC)
+- https://github.com/mateusreb/AntiCheat
+- https://github.com/0xrawsec/whids [EDR]
+- https://github.com/Neo23x0/Raccine [EDR]
+- https://github.com/AlSch092/UltimateAntiCheat
+- https://github.com/JonathanBerkeley/Quack
+- [Source Engine serverside anti-cheat plugin. (CS:S, CS:GO, CS:P, TF2)](https://github.com/kanekikun420/NoCheatZ-3)
+- [This is the Anti Cheat System for Knight Online Gamesoft vversion](https://github.com/luisfelipe18/GamesoftACS)
+- [User-mode C++ Anti-Cheat written for German Roleplay Server GVMP.de](https://github.com/divodeuxsevres/gvmp-anticheat)
+- [Cheat developer platform](https://github.com/c4kef/UAC)
 
 > Analysis Framework
 - https://github.com/pandora-analysis/pandora
@@ -1497,14 +1497,14 @@ Adds drag- to- resize functionality to the main GTA V window](https://github.com
 > Detection:Hook
 - https://github.com/hasherezade/pe-sieve
 - https://github.com/mike1k/HookHunter
-- https://github.com/gmh5225/Detect-hook-buster
-- https://github.com/gmh5225/Driver-Detect-nullshit
-- https://github.com/gmh5225/InstrumentationCallback-EtwTi-Syscall-Hook [Instrumentation Callback]
-- https://github.com/gmh5225/detect-scan-device-control-hooks-scanner [device-control-hooks-scanner]
+- https://github.com/st4ckh0und/hook-buster
+- https://github.com/TupleDev/nullshit
+- https://github.com/paranoidninja/EtwTi-Syscall-Hook [Instrumentation Callback]
+- https://github.com/Luchinkin/device-control-hooks-scanner [device-control-hooks-scanner]
 
 > Detection:Memory Integrity
-- https://github.com/gmh5225/integrity
-- https://github.com/gmh5225/Detect-QueryWorkingSetExample
+- https://github.com/afulsamet/integrity
+- https://github.com/Midi12/QueryWorkingSetExample
 
 > Detection:Attach
 - https://github.com/KANKOSHEV/Detect-KeAttachProcess
@@ -1513,73 +1513,73 @@ Adds drag- to- resize functionality to the main GTA V window](https://github.com
 - https://github.com/KANKOSHEV/Detect-MouseClassServiceCallback
 - https://github.com/changeofpace/MouHidInputHook
 - https://github.com/KelvinMsft/UsbMon
-- https://github.com/gmh5225/AntiCheat-DeepAimDetector [Deep Learning]
+- https://github.com/87andrewh/DeepAimDetector [Deep Learning]
 
 > Detection:Hide
 - https://github.com/KANKOSHEV/Detect-HiddenThread-via-KPRCB
-- https://github.com/gmh5225/Detect-HiddenThreads [KPRCB+PTE]
+- https://github.com/ekknod/Anti-Cheat-TestBench [KPRCB+PTE]
 - https://github.com/weak1337/SystemThreadFinder
-- https://github.com/gmh5225/HiddenModuleDetector
+- https://github.com/mq1n/HiddenModuleDetector
 - https://github.com/KelvinMsft/ThreadSpy
-- https://github.com/gmh5225/Detect-mapped-driver-Nomad [Mapped Driver]
-- https://github.com/gmh5225/detect-mapped-dll-ModFinder [Mapped Dll]
-- https://github.com/gmh5225/Driver-nmi-detect-NMIStackWalk [Mapped Driver by NMI Callback]
+- https://github.com/Rwkeith/Nomad [Mapped Driver]
+- https://github.com/Nou4r/ModFinder [Mapped Dll]
+- https://github.com/1401199262/NMIStackWalk [Mapped Driver by NMI Callback]
 
 > Detection:Vulnerable Driver
-- https://github.com/gmh5225/Driver-scan-hygieia
+- https://github.com/Deputation/hygieia
 
 > Detection: Hacked Hypervisor
 - https://secret.club/2020/04/13/how-anti-cheats-detect-system-emulation.html
 - https://github.com/helloobaby/Nmi-Callback [NMI Callback]
 - https://github.com/momo5502/ept-hook-detection [Detect EPT]
-- https://github.com/gmh5225/Detect-Hypervisor_detect_ring_0
+- https://github.com/Ahora57/Hypervisor_detect_ring_0
 
 > Detection:Virtual Environments 
 - https://github.com/a0rtega/pafish
 - https://github.com/gmh5225/Detection-Hyper-v [Hyper-v]
-- https://github.com/gmh5225/AntiDbg-MAJESTY-technologies
-- https://github.com/gmh5225/detect-anticuckoo [Cuckoo]
-- https://github.com/gmh5225/Android-anti-emulator [Android Anti-Emulator]
+- https://github.com/Ahora57/MAJESTY-technologies
+- https://github.com/therealdreg/anticuckoo [Cuckoo]
+- https://github.com/strazzere/anti-emulator [Android Anti-Emulator]
 
 > Detection:HWID
 - [All methods of retrieving unique identifiers(HWIDs) on your PC](https://www.unknowncheats.me/forum/anti-cheat-bypass/333662-methods-retrieving-unique-identifiers-hwids-pc.html)
 - https://github.com/medievalghoul/hwid-checker-mg
 - https://github.com/weak1337/NvidiaApi
-- https://github.com/gmh5225/HWID-WindowsHardwareInfo
+- https://github.com/paradoxwastaken/WindowsHardwareInfo
 
 > Detection:Injection
 - https://github.com/mq1n/DLLThreadInjectionDetector
-- https://github.com/gmh5225/detect-mapped-dll-ModFinder [Mapped Dll]
+- https://github.com/Nou4r/ModFinder [Mapped Dll]
 
 > Detection:ESP
 - https://github.com/weak1337/PresentHookDetection
 
 > Detection:Wall Hack
-- https://github.com/gmh5225/AntiCheat-CornerCulling
-- https://github.com/gmh5225/AntiCheat-CornerCullingSourceEngine
+- https://github.com/87andrewh/CornerCulling
+- https://github.com/87andrewh/CornerCullingSourceEngine
 
 > Detection:Obfuscation
 - https://github.com/mrphrazer/obfuscation_detection
 
 > Detection:Magisk
-- https://github.com/gmh5225/-Magisk-MagiskDetector
-- https://github.com/gmh5225/Detect-MagiskKiller
+- https://github.com/vvb2060/MagiskDetector
+- https://github.com/canyie/MagiskKiller
 
 > Signature Scanning
-- https://github.com/gmh5225/sig-binlex
-- https://github.com/gmh5225/sig-aho-corasick
+- https://github.com/c3rb3ru5d3d53c/binlex
+- https://github.com/mischasan/aho-corasick
 
 > Information System
 - https://github.com/Enum0x539/Qvoid-Token-Grabber
-- https://github.com/gmh5225/dfirtriage
-- https://github.com/gmh5225/info-LaZagne
+- https://github.com/travisfoley/dfirtriage
+- https://github.com/AlessandroZ/LaZagne
 - https://github.com/thewhiteninja/ntfstool
-- https://github.com/gmh5225/ntfs-journal-viewer
-- https://github.com/gmh5225/forensics-volatility
-- https://github.com/gmh5225/forensics-volatility3
-- [Decrypt and export browser password, including Chromium,Edge and Firefox](https://github.com/gmh5225/info-BrowserPasswordExportor)
-- https://github.com/gmh5225/Info-VolatileDataCollector
-- https://github.com/gmh5225/Tool-net-netview
+- https://github.com/mgeeky/ntfs-journal-viewer
+- https://github.com/volatilityfoundation/volatility
+- https://github.com/volatilityfoundation/volatility3
+- [Decrypt and export browser password, including Chromium,Edge and Firefox](https://github.com/BL0odz/BrowserPasswordExportor)
+- https://github.com/gtworek/VolatileDataCollector
+- https://github.com/mubix/netview
 
 > Dynamic Script
 - https://github.com/can1357/NtLua
@@ -1587,39 +1587,39 @@ Adds drag- to- resize functionality to the main GTA V window](https://github.com
 - https://github.com/jnz/q3vm
 
 > Kernel Mode Winsock
-- https://github.com/gmh5225/libwsk [Kernel-Mode Winsock library]
+- https://github.com/MiroKaku/libwsk [Kernel-Mode Winsock library]
 
 > Fuzzer
-- https://github.com/gmh5225/fuzzer-wtf
+- https://github.com/0vercl0k/wtf
 - https://null2root.github.io/blog/2022/07/21/When-Hypervisor-Met-Snapshot-Fuzzing.html
 
 > OpenCV
-- https://github.com/gmh5225/OpenCV-Rust-Auto-Weapon-Detection-Example
+- https://github.com/YouNeverKnow00/Rust-Auto-Weapon-Detection-OpenCV-Example
 
 > Windows Ring3 Callback
-- https://github.com/gmh5225/Callback-AlternativeShellcodeExec
+- https://github.com/aahmad097/AlternativeShellcodeExec
 - https://github.com/Deputation/instrumentation_callbacks [Instrumentation Callback]
-- https://github.com/gmh5225/Hooking-via-InstrumentationCallback [Instrumentation Callback]
-- https://github.com/gmh5225/InstrumentationCallback-EtwTi-Syscall-Hook [Instrumentation Callback]
-- [Register VEH by hooking RtlpCallVectoredHandlers](https://github.com/gmh5225/custom-VEH)
-- [ATPMiniDump Callback](https://github.com/gmh5225/Callback-ATPMiniDump)
-- https://github.com/gmh5225/readdirectorychanges [ReadDirectoryChangesW]
-- https://github.com/gmh5225/dllnotif [DllNotification]
+- https://github.com/secrary/Hooking-via-InstrumentationCallback [Instrumentation Callback]
+- https://github.com/paranoidninja/EtwTi-Syscall-Hook [Instrumentation Callback]
+- [Register VEH by hooking RtlpCallVectoredHandlers](https://github.com/AmJayden/custom-VEH)
+- [ATPMiniDump Callback](https://github.com/b4rtik/ATPMiniDump)
+- https://github.com/jimbeveridge/readdirectorychanges [ReadDirectoryChangesW]
+- https://github.com/blaquee/dllnotif [DllNotification]
 - https://github.com/gmh5225/LdrRegisterDllNotification-modify-testing [DllNotification]
 
 > Windows Ring0 Callback
 - [Enumerate Callback](https://github.com/hfiref0x/WinObjEx64/blob/7284d711b2eeebfd965713fc79353b9b76e23083/Source/WinObjEx64/extras/extrasCallbacks.c#L117)
-- [ImageNotify Callback With RtlWalkFrameChain](https://github.com/gmh5225/Driver-RtlWalkFrameChain-PsImageNotifyRoutineSpamFilter)
+- [ImageNotify Callback With RtlWalkFrameChain](https://github.com/Staatsgeheim/PsImageNotifyRoutineSpamFilter)
 - [SymlinkCallback](https://github.com/yardenshafir/SymlinkCallback)
 
 > Winows Kernel Dump Analysis
 - https://github.com/gmh5225/Tool-DIYSystemMemoryDump [DIY Dump Type]
 
 > Sign Tools
-- https://github.com/gmh5225/signtool-osslsigncode
+- https://github.com/mtrojnar/osslsigncode
 
 > Backup File
-- https://github.com/gmh5225/Driver-minivers [Generates Backup Copies]
+- https://github.com/guidoreina/minivers [Generates Backup Copies]
 
 > Black Signature
 - https://github.com/gmh5225/BlackSignatureDriver
@@ -1629,10 +1629,10 @@ Adds drag- to- resize functionality to the main GTA V window](https://github.com
 - https://www.unknowncheats.me/forum/general-programming-and-reversing/495279-messagebox-kernel-mode.html [Msgbox]
 - https://back.engineering/01/12/2020/ [Page Table Manipulation]
 - https://back.engineering/29/03/2021 [Hide Address]
-- https://github.com/gmh5225/be-injector [Attack COW]
-- https://github.com/gmh5225/eac-mapper [Vulnerable MmCopyMemory]
-- https://github.com/gmh5225/EAC-MmCopyMemory-EAC [Bypass MmCopyMemory]
-- https://github.com/gmh5225/be-injector [Attack COW]
+- https://github.com/Compiled-Code/be-injector [Attack COW]
+- https://github.com/Compiled-Code/eac-mapper [Vulnerable MmCopyMemory]
+- https://github.com/EBalloon/MmCopyMemory [Bypass MmCopyMemory]
+- https://github.com/Compiled-Code/be-injector [Attack COW]
 - https://github.com/gmh5225/Allocating-individual-pages [MmAllocateIndependentPagesEx]
 - https://github.com/gmh5225/Hook-HvlSwitchVirtualAddressSpace [HvlSwitchVirtualAddressSpace]
 - https://github.com/gmh5225/CallMeWin32kDriver [Load your driver like win32k.sys]
@@ -1640,20 +1640,20 @@ Adds drag- to- resize functionality to the main GTA V window](https://github.com
 
 > Windows Ring3
 - https://secret.club/2021/01/04/thread-stuff.html [Anti Debug]
-- https://github.com/gmh5225/signtool-PastDSE [Sign Leaked Cert]
-- https://github.com/gmh5225/StealingSignatures [Stealing signatures from pe files]
+- https://github.com/utoni/PastDSE [Sign Leaked Cert]
+- https://github.com/Sentient111/StealingSignatures [Stealing signatures from pe files]
 - https://github.com/secretsquirrel/SigThief [Stealing signatures from pe files]
-- https://github.com/gmh5225/ci-sign-fake-LazySign [Fake Cert]
-- https://github.com/gmh5225/MiniDumpWriteDumpPoC [Dump Memory]
+- https://github.com/jfmaes/LazySign [Fake Cert]
+- https://github.com/Adepts-Of-0xCC/MiniDumpWriteDumpPoC [Dump Memory]
 - [A x64 Write-What-Where exploit+shellcode execution vulnerability](https://www.unknowncheats.me/forum/anti-cheat-bypass/503519-wwwaryasinject-x64-write-exploit-shellcode-execution-vulnerability.html)
-- [Dll injection through code page id modification in registry](https://github.com/gmh5225/injection-NlsCodeInjectionThroughRegistry)
-- https://github.com/gmh5225/Etw-Syscall [ETW Syscall]
-- https://github.com/gmh5225/HOOK-SkipHook [Skip Hook]
+- [Dll injection through code page id modification in registry](https://github.com/NtQuerySystemInformation/NlsCodeInjectionThroughRegistry)
+- https://github.com/huoji120/Etw-Syscall [ETW Syscall]
+- https://github.com/weak1337/SkipHook [Skip Hook]
 
 > Android
-- https://github.com/gmh5225/Android-bypassHiddenApiRestriction [Bypass hidden api restriction]
-- https://github.com/gmh5225/Android-HiddenApiBypass [Bypass hidden api restriction]
-- https://github.com/gmh5225/Android-apk-ASCTool [Apk Signature Crack Tool]
+- https://github.com/WindySha/bypassHiddenApiRestriction [Bypass hidden api restriction]
+- https://github.com/LSPosed/AndroidHiddenApiBypass [Bypass hidden api restriction]
+- https://github.com/stars-one/ASCTool [Apk Signature Crack Tool]
 
 
 ## Windows Security Features
@@ -1663,14 +1663,14 @@ Adds drag- to- resize functionality to the main GTA V window](https://github.com
 - https://github.com/gmh5225/QueryShadowStack [Shadow Stack]
 
 ## Windows Subsystem for Android
-- https://github.com/gmh5225/win11_apk_installer
+- https://github.com/sergiovillaverde/win11_apk_installer
 - https://github.com/LSPosed/MagiskOnWSA
-- https://github.com/gmh5225/wsa_pacman
-- https://github.com/gmh5225/WSA-Linux-Kernel
-- https://github.com/gmh5225/BuildWSA
-- https://github.com/gmh5225/MagiskOnWSALocal
+- https://github.com/alesimula/wsa_pacman
+- https://github.com/WSA-Community/WSA-Linux-Kernel
+- https://github.com/Paxxs/BuildWSA
+- https://github.com/LSPosed/MagiskOnWSALocal
 
 ## Android Emulator
 - https://github.com/Genymobile
-- https://github.com/gmh5225/genymotion-kernel
-- https://github.com/gmh5225/android-emulator
+- https://github.com/Genymobile/genymotion-kernel
+- https://github.com/jwmcglynn/android-emulator

--- a/scripts/remove-forks.py
+++ b/scripts/remove-forks.py
@@ -1,0 +1,76 @@
+import urllib.request
+import re
+import json
+import sys
+
+# tokens are required because the rate limit for unauthenticated users is only
+# 60/h whereas authenticated users get 5000 requests. As of time of writing,
+# this repository contains ~1000 links which fits within the budget.
+if len(sys.argv) <= 1:
+    print("Usage: %s <github_token>" % (sys.argv[0]))
+    print("You can get a token from https://github.com/settings/tokens")
+    exit()
+
+token = sys.argv[1]
+
+if not token.startswith("ghp_"):
+    print("Github token should start with 'ghp_', ensure you got your token from https://github.com/settings/tokens.")
+    exit()
+
+filename = "../README.md"
+repo_regex = r'https:\/\/github.com\/([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)'
+
+# NOTE: for speed, uncomment the following line to only check repositories from specific users
+# repo_regex = r'https:\/\/github.com\/(gmh5225)\/([A-Za-z0-9_.-]+)'
+
+f = open(filename,"r")
+readme_content = f.read()
+f.close()
+
+# print(readme_content)
+
+# to give the user an idea how long this takes, print the amount of matches
+matchcount = len(re.findall(repo_regex, readme_content))
+matches_processed = 0
+
+def get_json(url):
+    req = urllib.request.Request(url)
+    req.add_header("Authorization", "token " + token)
+    resp = urllib.request.urlopen(req)
+    content = json.loads(resp.read())
+    resp.close()
+    return content
+
+def replace(match):
+    global matches_processed
+    global matchcount
+    matches_processed += 1
+    try:
+        username = match.group(1)
+        project = match.group(2)
+        print("checking %s/%s (%i/%i)" % (username, project, matches_processed, matchcount))
+        repo_info = get_json("https://api.github.com/repos/%s/%s" % (username, project))
+
+        if repo_info["fork"]:
+            print("\tproject is a fork from %s" % repo_info["parent"]["owner"]["login"])
+            stars_fork = repo_info["stargazers_count"]
+            stars_orig = repo_info["parent"]["stargazers_count"]
+            print("\torig: %s stars, fork: %s stars" % (stars_orig, stars_fork))
+            if stars_fork < 5 or stars_fork * 5 < stars_orig:
+                print('\tassuming that this fork does not add value, replacing with original')
+                return r'https://github.com/%s/%s' % (repo_info["parent"]["owner"]["login"], repo_info["parent"]["name"])
+        else:
+            print("\tproject is not a fork")
+
+        return r'https://github.com/%s/%s' % (username, project)
+    except Exception as e:
+        print('\tException occurred!', e)
+        return match.group(0)
+
+replaced = re.sub(repo_regex, replace, readme_content)
+# print(replaced)
+
+# write new file
+f = open(filename, "w")
+f.write(replaced)
+f.close()


### PR DESCRIPTION
This PR adds a script to scan the readme for forks that have significantly less stars than their parent and swaps these forks with a link to the original repository.

Note that the script requires a github personal access token since we're sending many requests to the github API. The source code contains instructions on how to limit which links are checked.

Closes #4