### PR TITLE
Add table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,30 @@
 ![Gitee license](https://img.shields.io/badge/license-MIT-blue.svg)
 # `awesome-game-security`
 
+## Contents
+- [Game Engine](#Game-Engine)
+- [Mathematics](#Mathematics)
+- [Renderer](#Renderer)
+- [3D Graphics](#3D-Graphics)
+- [AI](#AI)
+- [Image Codec](#Image-Codec)
+- [Wavefront Obj](#Wavefront-Obj)
+- [Task Scheduler](#Task-Scheduler)
+- [Game Network](#Game-Network)
+- [NVIDIA PhysX SDK](#NVIDIA-PhysX-SDK)
+- [Game Develop](#Game-Develop)
+- [Game Assets](#Game-Assets)
+- [Game Hot Patch](#Game-Hot-Patch)
+- [Game Testing](#Game-Testing)
+- [Game Tools](#Game-Tools)
+- [DirectX](#DirectX)
+- [Cheat](#Cheat)
+- [Anti Cheat](#Anti-Cheat)
+- [Some Tricks](#Some-Tricks)
+- [Windows Security Features](#Windows-Security-Features)
+- [Windows Subsystem for Android](#Windows-Subsystem-for-Android)
+- [Android Emulator](#Android-Emulator)
+
 ## Game Engine
 > Guide
 - https://github.com/QianMo/Game-Programmer-Study-Notes

--- a/scripts/generate-toc.py
+++ b/scripts/generate-toc.py
@@ -1,0 +1,39 @@
+filename = "../README.md"
+insert_line = 3
+
+indent_lookup = {
+    '## ': 0,
+    '### ': 1, # unused right now
+    '#### ': 2, # unused right now
+}
+
+
+found_items = []
+
+f = open(filename, "r")
+readme_lines = f.readlines()
+f.close()
+
+for line in readme_lines:
+    for prefix in indent_lookup:
+        if line.startswith(prefix):
+            heading = line[len(prefix):].strip()
+            heading_ref = heading.replace(' ', '-')
+            found_items.append('%s- [%s](#%s)' % ('\t' * indent_lookup[prefix], heading, heading_ref))
+    pass
+
+for item in found_items:
+    print(item)
+
+readme_lines.insert(insert_line, '## Contents\n')
+
+for i in range(len(found_items)):
+    item = found_items[i]
+    readme_lines.insert(insert_line + i + 1, item + '\n')
+    pass
+
+readme_lines.insert(insert_line + len(found_items) + 1, '\n')
+
+f = open(filename, "w")
+f.writelines(readme_lines)
+f.close()


### PR DESCRIPTION
This PR adds a script to generate a table of contents. This allows for an easy overview of what the list contains.

Before running the script yourself, remove the old table of contents. It should also support nested headings but you currently use quotes for subheadings (`>`) which cannot be navigated to. Replacing them with headings (`### `) should allow this.

The code to generate the `heading_ref` may not work for some special characters but none of them currently occur in the top-level headings so I haven't bothered with them yet.